### PR TITLE
Fixed rounding error in division operations.

### DIFF
--- a/src/OpenTK/Math/Vector2.cs
+++ b/src/OpenTK/Math/Vector2.cs
@@ -623,7 +623,8 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector2 vector, float scale, out Vector2 result)
         {
-            result = vector / scale;
+            result.X = vector.X / scale;
+            result.Y = vector.Y / scale;
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Vector2.cs
+++ b/src/OpenTK/Math/Vector2.cs
@@ -623,7 +623,7 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector2 vector, float scale, out Vector2 result)
         {
-            Multiply(ref vector, 1 / scale, out result);
+            result = vector / scale;
         }
 
         /// <summary>
@@ -1074,7 +1074,7 @@ namespace OpenTK
             vec.Y *= scale.Y;
             return vec;
         }
-		
+
         /// <summary>
         /// Divides the specified instance by a scalar.
         /// </summary>
@@ -1083,9 +1083,8 @@ namespace OpenTK
         /// <returns>Result of the division.</returns>
         public static Vector2 operator /(Vector2 vec, float scale)
         {
-            float mult = 1.0f / scale;
-            vec.X *= mult;
-            vec.Y *= mult;
+            vec.X /= scale;
+            vec.Y /= scale;
             return vec;
         }
 

--- a/src/OpenTK/Math/Vector2d.cs
+++ b/src/OpenTK/Math/Vector2d.cs
@@ -541,7 +541,8 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector2d vector, double scale, out Vector2d result)
         {
-            result = vector / scale;
+            result.X = vector.X / scale;
+            result.Y = vector.Y / scale;
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Vector2d.cs
+++ b/src/OpenTK/Math/Vector2d.cs
@@ -541,7 +541,7 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector2d vector, double scale, out Vector2d result)
         {
-            Multiply(ref vector, 1 / scale, out result);
+            result = vector / scale;
         }
 
         /// <summary>
@@ -936,7 +936,7 @@ namespace OpenTK
             vec.Y *= scale.Y;
             return vec;
         }
-		
+
         /// <summary>
         /// Divides an instance by a scalar.
         /// </summary>
@@ -945,9 +945,8 @@ namespace OpenTK
         /// <returns>The result of the operation.</returns>
         public static Vector2d operator /(Vector2d vec, double f)
         {
-            double mult = 1.0 / f;
-            vec.X *= mult;
-            vec.Y *= mult;
+            vec.X /= f;
+            vec.Y /= f;
             return vec;
         }
 

--- a/src/OpenTK/Math/Vector3.cs
+++ b/src/OpenTK/Math/Vector3.cs
@@ -629,7 +629,9 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector3 vector, float scale, out Vector3 result)
         {
-            result = vector / scale;
+            result.X = vector.X / scale;
+            result.Y = vector.Y / scale;
+            result.Z = vector.Z / scale;
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Vector3.cs
+++ b/src/OpenTK/Math/Vector3.cs
@@ -629,7 +629,7 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector3 vector, float scale, out Vector3 result)
         {
-            Multiply(ref vector, 1 / scale, out result);
+            result = vector / scale;
         }
 
         /// <summary>
@@ -1270,10 +1270,10 @@ namespace OpenTK
         {
             Vector4 result;
 
-            result.X = 
-                vector.X * worldViewProjection.M11 + 
-                vector.Y * worldViewProjection.M21 + 
-                vector.Z * worldViewProjection.M31 + 
+            result.X =
+                vector.X * worldViewProjection.M11 +
+                vector.Y * worldViewProjection.M21 +
+                vector.Z * worldViewProjection.M31 +
                 worldViewProjection.M41;
 
             result.Y =
@@ -1574,10 +1574,9 @@ namespace OpenTK
         /// <returns>The result of the calculation.</returns>
         public static Vector3 operator /(Vector3 vec, float scale)
         {
-            float mult = 1.0f / scale;
-            vec.X *= mult;
-            vec.Y *= mult;
-            vec.Z *= mult;
+            vec.X /= scale;
+            vec.Y /= scale;
+            vec.Z /= scale;
             return vec;
         }
 

--- a/src/OpenTK/Math/Vector3d.cs
+++ b/src/OpenTK/Math/Vector3d.cs
@@ -627,7 +627,9 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector3d vector, double scale, out Vector3d result)
         {
-            result = vector / scale;
+            result.X = vector.X / scale;
+            result.Y = vector.Y / scale;
+            result.Z = vector.Z / scale;
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Vector3d.cs
+++ b/src/OpenTK/Math/Vector3d.cs
@@ -627,7 +627,7 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector3d vector, double scale, out Vector3d result)
         {
-            Multiply(ref vector, 1 / scale, out result);
+            result = vector / scale;
         }
 
         /// <summary>
@@ -1372,7 +1372,7 @@ namespace OpenTK
             vec.Z *= scale;
             return vec;
         }
-		
+
         /// <summary>
         /// Component-wise multiplication between the specified instance by a scale vector.
         /// </summary>
@@ -1386,7 +1386,7 @@ namespace OpenTK
             vec.Z *= scale.Z;
             return vec;
         }
-		
+
         /// <summary>
         /// Divides an instance by a scalar.
         /// </summary>
@@ -1395,10 +1395,9 @@ namespace OpenTK
         /// <returns>The result of the calculation.</returns>
         public static Vector3d operator /(Vector3d vec, double scale)
         {
-            double mult = 1 / scale;
-            vec.X *= mult;
-            vec.Y *= mult;
-            vec.Z *= mult;
+            vec.X /= scale;
+            vec.Y /= scale;
+            vec.Z /= scale;
             return vec;
         }
 

--- a/src/OpenTK/Math/Vector4.cs
+++ b/src/OpenTK/Math/Vector4.cs
@@ -665,7 +665,10 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector4 vector, float scale, out Vector4 result)
         {
-            result = vector / scale;
+            result.X = vector.X / scale;
+            result.Y = vector.Y / scale;
+            result.Z = vector.Z / scale;
+            result.W = vector.W / scale;
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Vector4.cs
+++ b/src/OpenTK/Math/Vector4.cs
@@ -514,11 +514,10 @@ namespace OpenTK
         /// <returns>Result of the division</returns>
         public static Vector4 Div(Vector4 a, float f)
         {
-            float mult = 1.0f / f;
-            a.X *= mult;
-            a.Y *= mult;
-            a.Z *= mult;
-            a.W *= mult;
+            a.X /= f;
+            a.Y /= f;
+            a.Z /= f;
+            a.W /= f;
             return a;
         }
 
@@ -530,11 +529,10 @@ namespace OpenTK
         /// <param name="result">Result of the division</param>
         public static void Div(ref Vector4 a, float f, out Vector4 result)
         {
-            float mult = 1.0f / f;
-            result.X = a.X * mult;
-            result.Y = a.Y * mult;
-            result.Z = a.Z * mult;
-            result.W = a.W * mult;
+            result.X = a.X / f;
+            result.Y = a.Y / f;
+            result.Z = a.Z / f;
+            result.W = a.W / f;
         }
 
         #endregion
@@ -667,7 +665,7 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector4 vector, float scale, out Vector4 result)
         {
-            Multiply(ref vector, 1 / scale, out result);
+            result = vector / scale;
         }
 
         /// <summary>
@@ -1514,7 +1512,7 @@ namespace OpenTK
             vec.W *= scale;
             return vec;
         }
-        
+
         /// <summary>
         /// Component-wise multiplication between the specified instance by a scale vector.
         /// </summary>
@@ -1577,11 +1575,10 @@ namespace OpenTK
         /// <returns>The result of the calculation.</returns>
         public static Vector4 operator /(Vector4 vec, float scale)
         {
-            float mult = 1.0f / scale;
-            vec.X *= mult;
-            vec.Y *= mult;
-            vec.Z *= mult;
-            vec.W *= mult;
+            vec.X /= scale;
+            vec.Y /= scale;
+            vec.Z /= scale;
+            vec.W /= scale;
             return vec;
         }
 

--- a/src/OpenTK/Math/Vector4d.cs
+++ b/src/OpenTK/Math/Vector4d.cs
@@ -669,7 +669,10 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector4d vector, double scale, out Vector4d result)
         {
-            result = vector / scale;
+            result.X = vector.X / scale;
+            result.Y = vector.Y / scale;
+            result.Z = vector.Z / scale;
+            result.W = vector.W / scale;
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Vector4d.cs
+++ b/src/OpenTK/Math/Vector4d.cs
@@ -175,7 +175,7 @@ namespace OpenTK
         #endregion
 
         #region Public Members
-        
+
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
@@ -669,7 +669,7 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector4d vector, double scale, out Vector4d result)
         {
-            Multiply(ref vector, 1 / scale, out result);
+            result = vector / scale;
         }
 
         /// <summary>
@@ -1493,7 +1493,7 @@ namespace OpenTK
             vec.W *= scale;
             return vec;
         }
-		
+
         /// <summary>
         /// Component-wise multiplication between the specified instance by a scale vector.
         /// </summary>
@@ -1517,11 +1517,10 @@ namespace OpenTK
         /// <returns>The result of the calculation.</returns>
         public static Vector4d operator /(Vector4d vec, double scale)
         {
-            double mult = 1 / scale;
-            vec.X *= mult;
-            vec.Y *= mult;
-            vec.Z *= mult;
-            vec.W *= mult;
+            vec.X /= scale;
+            vec.Y /= scale;
+            vec.Z /= scale;
+            vec.W /= scale;
             return vec;
         }
 


### PR DESCRIPTION
This PR eliminates an additional step in the division calculations of the vector types. By transforming the dividend into a coefficient, an addition opportunity for rounding errors creep in. This is not usually a problem, but for fringe values near zero it may cause a rollover - turning values which should equal 1 or 0 into Infinity.

Removing this extra step and performing a direct float-float division (as defined in the division operator and used in some, but not all, of the division functions) produces expected values for all given inputs.