### PR TITLE
Mark Min/Max as obsolete and implement ComponentMin/Max and MagnitudeMin/Max for all vector classes.

### DIFF
--- a/src/OpenTK/Math/Vector2.cs
+++ b/src/OpenTK/Math/Vector2.cs
@@ -709,6 +709,64 @@ namespace OpenTK
 
         #endregion
 
+        #region MagnitudeMin
+
+        /// <summary>
+        /// Returns the Vector2 with the minimum magnitude. If the magnitudes are equal, the second vector
+        /// is selected.
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <returns>The minimum Vector2</returns>
+        public static Vector2 MagnitudeMin(Vector2 left, Vector2 right)
+        {
+            return left.LengthSquared < right.LengthSquared ? left : right;
+        }
+
+        /// <summary>
+        /// Returns the Vector2 with the minimum magnitude. If the magnitudes are equal, the second vector
+        /// is selected.
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <param name="result">The magnitude-wise minimum</param>
+        /// <returns>The minimum Vector2</returns>
+        public static void MagnitudeMin(ref Vector2 left, ref Vector2 right, out Vector2 result)
+        {
+            result = left.LengthSquared < right.LengthSquared ? left : right;
+        }
+
+        #endregion
+
+        #region MagnitudeMax
+
+        /// <summary>
+        /// Returns the Vector2 with the maximum magnitude. If the magnitudes are equal, the first vector
+        /// is selected.
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <returns>The maximum Vector2</returns>
+        public static Vector2 MagnitudeMax(Vector2 left, Vector2 right)
+        {
+            return left.LengthSquared >= right.LengthSquared ? left : right;
+        }
+
+        /// <summary>
+        /// Returns the Vector2 with the maximum magnitude. If the magnitudes are equal, the first vector
+        /// is selected.
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <param name="result">The magnitude-wise maximum</param>
+        /// <returns>The maximum Vector2</returns>
+        public static void MagnitudeMax(ref Vector2 left, ref Vector2 right, out Vector2 result)
+        {
+            result = left.LengthSquared >= right.LengthSquared ? left : right;
+        }
+
+        #endregion
+
         #region Min
 
         /// <summary>

--- a/src/OpenTK/Math/Vector2.cs
+++ b/src/OpenTK/Math/Vector2.cs
@@ -717,6 +717,7 @@ namespace OpenTK
         /// <param name="left">Left operand</param>
         /// <param name="right">Right operand</param>
         /// <returns>The minimum Vector3</returns>
+        [Obsolete("Use MagnitudeMin() instead.")]
         public static Vector2 Min(Vector2 left, Vector2 right)
         {
             return left.LengthSquared < right.LengthSquared ? left : right;
@@ -732,6 +733,7 @@ namespace OpenTK
         /// <param name="left">Left operand</param>
         /// <param name="right">Right operand</param>
         /// <returns>The minimum Vector3</returns>
+        [Obsolete("Use MagnitudeMax() instead.")]
         public static Vector2 Max(Vector2 left, Vector2 right)
         {
             return left.LengthSquared >= right.LengthSquared ? left : right;
@@ -1074,7 +1076,7 @@ namespace OpenTK
             vec.Y *= scale.Y;
             return vec;
         }
-		
+
         /// <summary>
         /// Divides the specified instance by a scalar.
         /// </summary>

--- a/src/OpenTK/Math/Vector2.cs
+++ b/src/OpenTK/Math/Vector2.cs
@@ -654,7 +654,7 @@ namespace OpenTK
         #region ComponentMin
 
         /// <summary>
-        /// Calculate the component-wise minimum of two vectors
+        /// Returns a vector created from the smallest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -667,7 +667,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Calculate the component-wise minimum of two vectors
+        /// Returns a vector created from the smallest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -683,7 +683,7 @@ namespace OpenTK
         #region ComponentMax
 
         /// <summary>
-        /// Calculate the component-wise maximum of two vectors
+        /// Returns a vector created from the largest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -696,7 +696,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Calculate the component-wise maximum of two vectors
+        /// Returns a vector created from the largest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>

--- a/src/OpenTK/Math/Vector2d.cs
+++ b/src/OpenTK/Math/Vector2d.cs
@@ -692,7 +692,8 @@ namespace OpenTK
         #region MagnitudeMin
 
         /// <summary>
-        /// Returns the Vector2d with the minimum magnitude
+        /// Returns the Vector2d with the minimum magnitude. If the magnitudes are equal, the second vector
+        /// is selected.
         /// </summary>
         /// <param name="left">Left operand</param>
         /// <param name="right">Right operand</param>
@@ -703,7 +704,8 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Returns the Vector2d with the minimum magnitude
+        /// Returns the Vector2d with the minimum magnitude. If the magnitudes are equal, the second vector
+        /// is selected.
         /// </summary>
         /// <param name="left">Left operand</param>
         /// <param name="right">Right operand</param>
@@ -719,7 +721,8 @@ namespace OpenTK
         #region MagnitudeMax
 
         /// <summary>
-        /// Returns the Vector2d with the minimum magnitude
+        /// Returns the Vector2d with the minimum magnitude. If the magnitudes are equal, the first vector
+        /// is selected.
         /// </summary>
         /// <param name="left">Left operand</param>
         /// <param name="right">Right operand</param>
@@ -730,7 +733,8 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Returns the Vector2d with the maximum magnitude
+        /// Returns the Vector2d with the maximum magnitude. If the magnitudes are equal, the first vector
+        /// is selected.
         /// </summary>
         /// <param name="left">Left operand</param>
         /// <param name="right">Right operand</param>

--- a/src/OpenTK/Math/Vector2d.cs
+++ b/src/OpenTK/Math/Vector2d.cs
@@ -577,6 +577,7 @@ namespace OpenTK
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
         /// <returns>The component-wise minimum</returns>
+        [Obsolete("Use ComponentMin() instead.")]
         public static Vector2d Min(Vector2d a, Vector2d b)
         {
             a.X = a.X < b.X ? a.X : b.X;
@@ -590,6 +591,7 @@ namespace OpenTK
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
         /// <param name="result">The component-wise minimum</param>
+        [Obsolete("Use ComponentMin() instead.")]
         public static void Min(ref Vector2d a, ref Vector2d b, out Vector2d result)
         {
             result.X = a.X < b.X ? a.X : b.X;
@@ -606,6 +608,7 @@ namespace OpenTK
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
         /// <returns>The component-wise maximum</returns>
+        [Obsolete("Use ComponentMax() instead.")]
         public static Vector2d Max(Vector2d a, Vector2d b)
         {
             a.X = a.X > b.X ? a.X : b.X;
@@ -619,6 +622,7 @@ namespace OpenTK
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
         /// <param name="result">The component-wise maximum</param>
+        [Obsolete("Use ComponentMax() instead.")]
         public static void Max(ref Vector2d a, ref Vector2d b, out Vector2d result)
         {
             result.X = a.X > b.X ? a.X : b.X;
@@ -936,7 +940,7 @@ namespace OpenTK
             vec.Y *= scale.Y;
             return vec;
         }
-		
+
         /// <summary>
         /// Divides an instance by a scalar.
         /// </summary>

--- a/src/OpenTK/Math/Vector2d.cs
+++ b/src/OpenTK/Math/Vector2d.cs
@@ -631,6 +631,118 @@ namespace OpenTK
 
         #endregion
 
+        #region ComponentMin
+
+        /// <summary>
+        /// Calculate the component-wise minimum of two vectors
+        /// </summary>
+        /// <param name="a">First operand</param>
+        /// <param name="b">Second operand</param>
+        /// <returns>The component-wise minimum</returns>
+        public static Vector2d ComponentMin(Vector2d a, Vector2d b)
+        {
+            a.X = a.X < b.X ? a.X : b.X;
+            a.Y = a.Y < b.Y ? a.Y : b.Y;
+            return a;
+        }
+
+        /// <summary>
+        /// Calculate the component-wise minimum of two vectors
+        /// </summary>
+        /// <param name="a">First operand</param>
+        /// <param name="b">Second operand</param>
+        /// <param name="result">The component-wise minimum</param>
+        public static void ComponentMin(ref Vector2d a, ref Vector2d b, out Vector2d result)
+        {
+            result.X = a.X < b.X ? a.X : b.X;
+            result.Y = a.Y < b.Y ? a.Y : b.Y;
+        }
+
+        #endregion
+
+        #region ComponentMax
+
+        /// <summary>
+        /// Calculate the component-wise maximum of two vectors
+        /// </summary>
+        /// <param name="a">First operand</param>
+        /// <param name="b">Second operand</param>
+        /// <returns>The component-wise maximum</returns>
+        public static Vector2d ComponentMax(Vector2d a, Vector2d b)
+        {
+            a.X = a.X > b.X ? a.X : b.X;
+            a.Y = a.Y > b.Y ? a.Y : b.Y;
+            return a;
+        }
+
+        /// <summary>
+        /// Calculate the component-wise maximum of two vectors
+        /// </summary>
+        /// <param name="a">First operand</param>
+        /// <param name="b">Second operand</param>
+        /// <param name="result">The component-wise maximum</param>
+        public static void ComponentMax(ref Vector2d a, ref Vector2d b, out Vector2d result)
+        {
+            result.X = a.X > b.X ? a.X : b.X;
+            result.Y = a.Y > b.Y ? a.Y : b.Y;
+        }
+
+        #endregion
+
+        #region MagnitudeMin
+
+        /// <summary>
+        /// Returns the Vector2d with the minimum magnitude
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <returns>The minimum Vector2d</returns>
+        public static Vector2d MagnitudeMin(Vector2d left, Vector2d right)
+        {
+            return left.LengthSquared < right.LengthSquared ? left : right;
+        }
+
+        /// <summary>
+        /// Returns the Vector2d with the minimum magnitude
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <param name="result">The magnitude-wise minimum</param>
+        /// <returns>The minimum Vector2d</returns>
+        public static void MagnitudeMin(ref Vector2d left, ref Vector2d right, out Vector2d result)
+        {
+            result = left.LengthSquared < right.LengthSquared ? left : right;
+        }
+
+        #endregion
+
+        #region MagnitudeMax
+
+        /// <summary>
+        /// Returns the Vector2d with the minimum magnitude
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <returns>The minimum Vector2d</returns>
+        public static Vector2d MagnitudeMax(Vector2d left, Vector2d right)
+        {
+            return left.LengthSquared >= right.LengthSquared ? left : right;
+        }
+
+        /// <summary>
+        /// Returns the Vector2d with the maximum magnitude
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <param name="result">The magnitude-wise maximum</param>
+        /// <returns>The maximum Vector2d</returns>
+        public static void MagnitudeMax(ref Vector2d left, ref Vector2d right, out Vector2d result)
+        {
+            result = left.LengthSquared >= right.LengthSquared ? left : right;
+        }
+
+        #endregion
+
         #region Clamp
 
         /// <summary>

--- a/src/OpenTK/Math/Vector2d.cs
+++ b/src/OpenTK/Math/Vector2d.cs
@@ -634,7 +634,7 @@ namespace OpenTK
         #region ComponentMin
 
         /// <summary>
-        /// Calculate the component-wise minimum of two vectors
+        /// Returns a vector created from the smallest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -647,7 +647,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Calculate the component-wise minimum of two vectors
+        /// Returns a vector created from the smallest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -663,7 +663,7 @@ namespace OpenTK
         #region ComponentMax
 
         /// <summary>
-        /// Calculate the component-wise maximum of two vectors
+        /// Returns a vector created from the largest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -676,7 +676,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Calculate the component-wise maximum of two vectors
+        /// Returns a vector created from the largest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>

--- a/src/OpenTK/Math/Vector3.cs
+++ b/src/OpenTK/Math/Vector3.cs
@@ -719,6 +719,64 @@ namespace OpenTK
 
         #endregion
 
+        #region MagnitudeMin
+
+        /// <summary>
+        /// Returns the Vector3 with the minimum magnitude. If the magnitudes are equal, the second vector
+        /// is selected.
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <returns>The minimum Vector3</returns>
+        public static Vector3 MagnitudeMin(Vector3 left, Vector3 right)
+        {
+            return left.LengthSquared < right.LengthSquared ? left : right;
+        }
+
+        /// <summary>
+        /// Returns the Vector3 with the minimum magnitude. If the magnitudes are equal, the second vector
+        /// is selected.
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <param name="result">The magnitude-wise minimum</param>
+        /// <returns>The minimum Vector3</returns>
+        public static void MagnitudeMin(ref Vector3 left, ref Vector3 right, out Vector3 result)
+        {
+            result = left.LengthSquared < right.LengthSquared ? left : right;
+        }
+
+        #endregion
+
+        #region MagnitudeMax
+
+        /// <summary>
+        /// Returns the Vector3 with the maximum magnitude. If the magnitudes are equal, the first vector
+        /// is selected.
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <returns>The maximum Vector3</returns>
+        public static Vector3 MagnitudeMax(Vector3 left, Vector3 right)
+        {
+            return left.LengthSquared >= right.LengthSquared ? left : right;
+        }
+
+        /// <summary>
+        /// Returns the Vector3 with the maximum magnitude. If the magnitudes are equal, the first vector
+        /// is selected.
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <param name="result">The magnitude-wise maximum</param>
+        /// <returns>The maximum Vector3</returns>
+        public static void MagnitudeMax(ref Vector3 left, ref Vector3 right, out Vector3 result)
+        {
+            result = left.LengthSquared >= right.LengthSquared ? left : right;
+        }
+
+        #endregion
+
         #region Min
 
         /// <summary>

--- a/src/OpenTK/Math/Vector3.cs
+++ b/src/OpenTK/Math/Vector3.cs
@@ -660,7 +660,7 @@ namespace OpenTK
         #region ComponentMin
 
         /// <summary>
-        /// Calculate the component-wise minimum of two vectors
+        /// Returns a vector created from the smallest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -674,7 +674,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Calculate the component-wise minimum of two vectors
+        /// Returns a vector created from the smallest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -691,7 +691,7 @@ namespace OpenTK
         #region ComponentMax
 
         /// <summary>
-        /// Calculate the component-wise maximum of two vectors
+        /// Returns a vector created from the largest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -705,7 +705,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Calculate the component-wise maximum of two vectors
+        /// Returns a vector created from the largest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>

--- a/src/OpenTK/Math/Vector3.cs
+++ b/src/OpenTK/Math/Vector3.cs
@@ -727,6 +727,7 @@ namespace OpenTK
         /// <param name="left">Left operand</param>
         /// <param name="right">Right operand</param>
         /// <returns>The minimum Vector3</returns>
+        [Obsolete("Use MagnitudeMin() instead.")]
         public static Vector3 Min(Vector3 left, Vector3 right)
         {
             return left.LengthSquared < right.LengthSquared ? left : right;
@@ -742,6 +743,7 @@ namespace OpenTK
         /// <param name="left">Left operand</param>
         /// <param name="right">Right operand</param>
         /// <returns>The minimum Vector3</returns>
+        [Obsolete("Use MagnitudeMax() instead.")]
         public static Vector3 Max(Vector3 left, Vector3 right)
         {
             return left.LengthSquared >= right.LengthSquared ? left : right;
@@ -1270,10 +1272,10 @@ namespace OpenTK
         {
             Vector4 result;
 
-            result.X = 
-                vector.X * worldViewProjection.M11 + 
-                vector.Y * worldViewProjection.M21 + 
-                vector.Z * worldViewProjection.M31 + 
+            result.X =
+                vector.X * worldViewProjection.M11 +
+                vector.Y * worldViewProjection.M21 +
+                vector.Z * worldViewProjection.M31 +
                 worldViewProjection.M41;
 
             result.Y =

--- a/src/OpenTK/Math/Vector3d.cs
+++ b/src/OpenTK/Math/Vector3d.cs
@@ -725,6 +725,7 @@ namespace OpenTK
         /// <param name="left">Left operand</param>
         /// <param name="right">Right operand</param>
         /// <returns>The minimum Vector3</returns>
+        [Obsolete("Use MagnitudeMin() instead.")]
         public static Vector3d Min(Vector3d left, Vector3d right)
         {
             return left.LengthSquared < right.LengthSquared ? left : right;
@@ -740,6 +741,7 @@ namespace OpenTK
         /// <param name="left">Left operand</param>
         /// <param name="right">Right operand</param>
         /// <returns>The minimum Vector3</returns>
+        [Obsolete("Use MagnitudeMax() instead.")]
         public static Vector3d Max(Vector3d left, Vector3d right)
         {
             return left.LengthSquared >= right.LengthSquared ? left : right;
@@ -1372,7 +1374,7 @@ namespace OpenTK
             vec.Z *= scale;
             return vec;
         }
-		
+
         /// <summary>
         /// Component-wise multiplication between the specified instance by a scale vector.
         /// </summary>
@@ -1386,7 +1388,7 @@ namespace OpenTK
             vec.Z *= scale.Z;
             return vec;
         }
-		
+
         /// <summary>
         /// Divides an instance by a scalar.
         /// </summary>

--- a/src/OpenTK/Math/Vector3d.cs
+++ b/src/OpenTK/Math/Vector3d.cs
@@ -717,6 +717,60 @@ namespace OpenTK
 
         #endregion
 
+        #region MagnitudeMin
+
+        /// <summary>
+        /// Returns the Vector3d with the minimum magnitude
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <returns>The minimum Vector3d</returns>
+        public static Vector3d MagnitudeMin(Vector3d left, Vector3d right)
+        {
+            return left.LengthSquared < right.LengthSquared ? left : right;
+        }
+
+        /// <summary>
+        /// Returns the Vector3d with the minimum magnitude
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <param name="result">The magnitude-wise minimum</param>
+        /// <returns>The minimum Vector3d</returns>
+        public static void MagnitudeMin(ref Vector3d left, ref Vector3d right, out Vector3d result)
+        {
+            result = left.LengthSquared < right.LengthSquared ? left : right;
+        }
+
+        #endregion
+
+        #region MagnitudeMax
+
+        /// <summary>
+        /// Returns the Vector3d with the minimum magnitude
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <returns>The minimum Vector3d</returns>
+        public static Vector3d MagnitudeMax(Vector3d left, Vector3d right)
+        {
+            return left.LengthSquared >= right.LengthSquared ? left : right;
+        }
+
+        /// <summary>
+        /// Returns the Vector3d with the maximum magnitude
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <param name="result">The magnitude-wise maximum</param>
+        /// <returns>The maximum Vector3d</returns>
+        public static void MagnitudeMax(ref Vector3d left, ref Vector3d right, out Vector3d result)
+        {
+            result = left.LengthSquared >= right.LengthSquared ? left : right;
+        }
+
+        #endregion
+
         #region Min
 
         /// <summary>

--- a/src/OpenTK/Math/Vector3d.cs
+++ b/src/OpenTK/Math/Vector3d.cs
@@ -658,7 +658,7 @@ namespace OpenTK
         #region ComponentMin
 
         /// <summary>
-        /// Calculate the component-wise minimum of two vectors
+        /// Returns a vector created from the smallest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -672,7 +672,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Calculate the component-wise minimum of two vectors
+        /// Returns a vector created from the smallest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -689,7 +689,7 @@ namespace OpenTK
         #region ComponentMax
 
         /// <summary>
-        /// Calculate the component-wise maximum of two vectors
+        /// Returns a vector created from the largest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -703,7 +703,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Calculate the component-wise maximum of two vectors
+        /// Returns a vector created from the largest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>

--- a/src/OpenTK/Math/Vector4.cs
+++ b/src/OpenTK/Math/Vector4.cs
@@ -765,6 +765,130 @@ namespace OpenTK
 
         #endregion
 
+        #region ComponentMin
+
+        /// <summary>
+        /// Calculate the component-wise minimum of two vectors
+        /// </summary>
+        /// <param name="a">First operand</param>
+        /// <param name="b">Second operand</param>
+        /// <returns>The component-wise minimum</returns>
+        public static Vector4 ComponentMin(Vector4 a, Vector4 b)
+        {
+            a.X = a.X < b.X ? a.X : b.X;
+            a.Y = a.Y < b.Y ? a.Y : b.Y;
+            a.Z = a.Z < b.Z ? a.Z : b.Z;
+            a.W = a.W < b.W ? a.W : b.W;
+            return a;
+        }
+
+        /// <summary>
+        /// Calculate the component-wise minimum of two vectors
+        /// </summary>
+        /// <param name="a">First operand</param>
+        /// <param name="b">Second operand</param>
+        /// <param name="result">The component-wise minimum</param>
+        public static void ComponentMin(ref Vector4 a, ref Vector4 b, out Vector4 result)
+        {
+            result.X = a.X < b.X ? a.X : b.X;
+            result.Y = a.Y < b.Y ? a.Y : b.Y;
+            result.Z = a.Z < b.Z ? a.Z : b.Z;
+            result.W = a.W < b.W ? a.W : b.W;
+        }
+
+        #endregion
+
+        #region ComponentMax
+
+        /// <summary>
+        /// Calculate the component-wise maximum of two vectors
+        /// </summary>
+        /// <param name="a">First operand</param>
+        /// <param name="b">Second operand</param>
+        /// <returns>The component-wise maximum</returns>
+        public static Vector4 ComponentMax(Vector4 a, Vector4 b)
+        {
+            a.X = a.X > b.X ? a.X : b.X;
+            a.Y = a.Y > b.Y ? a.Y : b.Y;
+            a.Z = a.Z > b.Z ? a.Z : b.Z;
+            a.W = a.W > b.W ? a.W : b.W;
+            return a;
+        }
+
+        /// <summary>
+        /// Calculate the component-wise maximum of two vectors
+        /// </summary>
+        /// <param name="a">First operand</param>
+        /// <param name="b">Second operand</param>
+        /// <param name="result">The component-wise maximum</param>
+        public static void ComponentMax(ref Vector4 a, ref Vector4 b, out Vector4 result)
+        {
+            result.X = a.X > b.X ? a.X : b.X;
+            result.Y = a.Y > b.Y ? a.Y : b.Y;
+            result.Z = a.Z > b.Z ? a.Z : b.Z;
+            result.W = a.W > b.W ? a.W : b.W;
+        }
+
+        #endregion
+
+        #region MagnitudeMin
+
+        /// <summary>
+        /// Returns the Vector4 with the minimum magnitude. If the magnitudes are equal, the second vector
+        /// is selected.
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <returns>The minimum Vector4</returns>
+        public static Vector4 MagnitudeMin(Vector4 left, Vector4 right)
+        {
+            return left.LengthSquared < right.LengthSquared ? left : right;
+        }
+
+        /// <summary>
+        /// Returns the Vector4 with the minimum magnitude. If the magnitudes are equal, the second vector
+        /// is selected.
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <param name="result">The magnitude-wise minimum</param>
+        /// <returns>The minimum Vector4</returns>
+        public static void MagnitudeMin(ref Vector4 left, ref Vector4 right, out Vector4 result)
+        {
+            result = left.LengthSquared < right.LengthSquared ? left : right;
+        }
+
+        #endregion
+
+        #region MagnitudeMax
+
+        /// <summary>
+        /// Returns the Vector4 with the maximum magnitude. If the magnitudes are equal, the first vector
+        /// is selected.
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <returns>The maximum Vector4</returns>
+        public static Vector4 MagnitudeMax(Vector4 left, Vector4 right)
+        {
+            return left.LengthSquared >= right.LengthSquared ? left : right;
+        }
+
+        /// <summary>
+        /// Returns the Vector4 with the maximum magnitude. If the magnitudes are equal, the first vector
+        /// is selected.
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <param name="result">The magnitude-wise maximum</param>
+        /// <returns>The maximum Vector4</returns>
+        public static void MagnitudeMax(ref Vector4 left, ref Vector4 right, out Vector4 result)
+        {
+            result = left.LengthSquared >= right.LengthSquared ? left : right;
+        }
+
+        #endregion
+
         #region Clamp
 
         /// <summary>

--- a/src/OpenTK/Math/Vector4.cs
+++ b/src/OpenTK/Math/Vector4.cs
@@ -703,6 +703,7 @@ namespace OpenTK
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
         /// <returns>The component-wise minimum</returns>
+        [Obsolete("Use ComponentMin() instead.")]
         public static Vector4 Min(Vector4 a, Vector4 b)
         {
             a.X = a.X < b.X ? a.X : b.X;
@@ -718,6 +719,7 @@ namespace OpenTK
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
         /// <param name="result">The component-wise minimum</param>
+        [Obsolete("Use ComponentMin() instead.")]
         public static void Min(ref Vector4 a, ref Vector4 b, out Vector4 result)
         {
             result.X = a.X < b.X ? a.X : b.X;
@@ -736,6 +738,7 @@ namespace OpenTK
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
         /// <returns>The component-wise maximum</returns>
+        [Obsolete("Use ComponentMax() instead.")]
         public static Vector4 Max(Vector4 a, Vector4 b)
         {
             a.X = a.X > b.X ? a.X : b.X;
@@ -751,6 +754,7 @@ namespace OpenTK
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
         /// <param name="result">The component-wise maximum</param>
+        [Obsolete("Use ComponentMax() instead.")]
         public static void Max(ref Vector4 a, ref Vector4 b, out Vector4 result)
         {
             result.X = a.X > b.X ? a.X : b.X;
@@ -1514,7 +1518,7 @@ namespace OpenTK
             vec.W *= scale;
             return vec;
         }
-        
+
         /// <summary>
         /// Component-wise multiplication between the specified instance by a scale vector.
         /// </summary>

--- a/src/OpenTK/Math/Vector4.cs
+++ b/src/OpenTK/Math/Vector4.cs
@@ -768,7 +768,7 @@ namespace OpenTK
         #region ComponentMin
 
         /// <summary>
-        /// Calculate the component-wise minimum of two vectors
+        /// Returns a vector created from the smallest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -783,7 +783,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Calculate the component-wise minimum of two vectors
+        /// Returns a vector created from the smallest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -801,7 +801,7 @@ namespace OpenTK
         #region ComponentMax
 
         /// <summary>
-        /// Calculate the component-wise maximum of two vectors
+        /// Returns a vector created from the largest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -816,7 +816,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Calculate the component-wise maximum of two vectors
+        /// Returns a vector created from the largest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>

--- a/src/OpenTK/Math/Vector4d.cs
+++ b/src/OpenTK/Math/Vector4d.cs
@@ -767,6 +767,126 @@ namespace OpenTK
 
         #endregion
 
+        #region ComponentMin
+
+        /// <summary>
+        /// Calculate the component-wise minimum of two vectors
+        /// </summary>
+        /// <param name="a">First operand</param>
+        /// <param name="b">Second operand</param>
+        /// <returns>The component-wise minimum</returns>
+        public static Vector4d ComponentMin(Vector4d a, Vector4d b)
+        {
+            a.X = a.X < b.X ? a.X : b.X;
+            a.Y = a.Y < b.Y ? a.Y : b.Y;
+            a.Z = a.Z < b.Z ? a.Z : b.Z;
+            a.W = a.W < b.W ? a.W : b.W;
+            return a;
+        }
+
+        /// <summary>
+        /// Calculate the component-wise minimum of two vectors
+        /// </summary>
+        /// <param name="a">First operand</param>
+        /// <param name="b">Second operand</param>
+        /// <param name="result">The component-wise minimum</param>
+        public static void ComponentMin(ref Vector4d a, ref Vector4d b, out Vector4d result)
+        {
+            result.X = a.X < b.X ? a.X : b.X;
+            result.Y = a.Y < b.Y ? a.Y : b.Y;
+            result.Z = a.Z < b.Z ? a.Z : b.Z;
+            result.W = a.W < b.W ? a.W : b.W;
+        }
+
+        #endregion
+
+        #region ComponentMax
+
+        /// <summary>
+        /// Calculate the component-wise maximum of two vectors
+        /// </summary>
+        /// <param name="a">First operand</param>
+        /// <param name="b">Second operand</param>
+        /// <returns>The component-wise maximum</returns>
+        public static Vector4d ComponentMax(Vector4d a, Vector4d b)
+        {
+            a.X = a.X > b.X ? a.X : b.X;
+            a.Y = a.Y > b.Y ? a.Y : b.Y;
+            a.Z = a.Z > b.Z ? a.Z : b.Z;
+            a.W = a.W > b.W ? a.W : b.W;
+            return a;
+        }
+
+        /// <summary>
+        /// Calculate the component-wise maximum of two vectors
+        /// </summary>
+        /// <param name="a">First operand</param>
+        /// <param name="b">Second operand</param>
+        /// <param name="result">The component-wise maximum</param>
+        public static void ComponentMax(ref Vector4d a, ref Vector4d b, out Vector4d result)
+        {
+            result.X = a.X > b.X ? a.X : b.X;
+            result.Y = a.Y > b.Y ? a.Y : b.Y;
+            result.Z = a.Z > b.Z ? a.Z : b.Z;
+            result.W = a.W > b.W ? a.W : b.W;
+        }
+
+        #endregion
+
+        #region MagnitudeMin
+
+        /// <summary>
+        /// Returns the Vector4d with the minimum magnitude
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <returns>The minimum Vector4d</returns>
+        public static Vector4d MagnitudeMin(Vector4d left, Vector4d right)
+        {
+            return left.LengthSquared < right.LengthSquared ? left : right;
+        }
+
+        /// <summary>
+        /// Returns the Vector4d with the minimum magnitude
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <param name="result">The magnitude-wise minimum</param>
+        /// <returns>The minimum Vector4d</returns>
+        public static void MagnitudeMin(ref Vector4d left, ref Vector4d right, out Vector4d result)
+        {
+            result = left.LengthSquared < right.LengthSquared ? left : right;
+        }
+
+        #endregion
+
+        #region MagnitudeMax
+
+        /// <summary>
+        /// Returns the Vector4d with the minimum magnitude
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <returns>The minimum Vector4d</returns>
+        public static Vector4d MagnitudeMax(Vector4d left, Vector4d right)
+        {
+            return left.LengthSquared >= right.LengthSquared ? left : right;
+        }
+
+        /// <summary>
+        /// Returns the Vector4d with the maximum magnitude
+        /// </summary>
+        /// <param name="left">Left operand</param>
+        /// <param name="right">Right operand</param>
+        /// <param name="result">The magnitude-wise maximum</param>
+        /// <returns>The maximum Vector4d</returns>
+        public static void MagnitudeMax(ref Vector4d left, ref Vector4d right, out Vector4d result)
+        {
+            result = left.LengthSquared >= right.LengthSquared ? left : right;
+        }
+
+        #endregion
+
         #region Clamp
 
         /// <summary>

--- a/src/OpenTK/Math/Vector4d.cs
+++ b/src/OpenTK/Math/Vector4d.cs
@@ -770,7 +770,7 @@ namespace OpenTK
         #region ComponentMin
 
         /// <summary>
-        /// Calculate the component-wise minimum of two vectors
+        /// Returns a vector created from the smallest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -785,7 +785,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Calculate the component-wise minimum of two vectors
+        /// Returns a vector created from the smallest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -803,7 +803,7 @@ namespace OpenTK
         #region ComponentMax
 
         /// <summary>
-        /// Calculate the component-wise maximum of two vectors
+        /// Returns a vector created from the largest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
@@ -818,7 +818,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Calculate the component-wise maximum of two vectors
+        /// Returns a vector created from the largest of the corresponding components of the given vectors.
         /// </summary>
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>

--- a/src/OpenTK/Math/Vector4d.cs
+++ b/src/OpenTK/Math/Vector4d.cs
@@ -175,7 +175,7 @@ namespace OpenTK
         #endregion
 
         #region Public Members
-        
+
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
@@ -705,6 +705,7 @@ namespace OpenTK
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
         /// <returns>The component-wise minimum</returns>
+        [Obsolete("Use ComponentMin() instead.")]
         public static Vector4d Min(Vector4d a, Vector4d b)
         {
             a.X = a.X < b.X ? a.X : b.X;
@@ -720,6 +721,7 @@ namespace OpenTK
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
         /// <param name="result">The component-wise minimum</param>
+        [Obsolete("Use ComponentMin() instead.")]
         public static void Min(ref Vector4d a, ref Vector4d b, out Vector4d result)
         {
             result.X = a.X < b.X ? a.X : b.X;
@@ -738,6 +740,7 @@ namespace OpenTK
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
         /// <returns>The component-wise maximum</returns>
+        [Obsolete("Use ComponentMax() instead.")]
         public static Vector4d Max(Vector4d a, Vector4d b)
         {
             a.X = a.X > b.X ? a.X : b.X;
@@ -753,6 +756,7 @@ namespace OpenTK
         /// <param name="a">First operand</param>
         /// <param name="b">Second operand</param>
         /// <param name="result">The component-wise maximum</param>
+        [Obsolete("Use ComponentMax() instead.")]
         public static void Max(ref Vector4d a, ref Vector4d b, out Vector4d result)
         {
             result.X = a.X > b.X ? a.X : b.X;
@@ -1493,7 +1497,7 @@ namespace OpenTK
             vec.W *= scale;
             return vec;
         }
-		
+
         /// <summary>
         /// Component-wise multiplication between the specified instance by a scale vector.
         /// </summary>

--- a/tests/OpenTK.Tests/Assertions.fs
+++ b/tests/OpenTK.Tests/Assertions.fs
@@ -9,7 +9,7 @@ open OpenTK
 [<AutoOpen>]
 module private AssertHelpers =
     [<Literal>]
-    let private BitAccuracy = 9
+    let private BitAccuracy = 10
 
     let approxEq a b = MathHelper.ApproximatelyEqual(a,b,BitAccuracy)
 

--- a/tests/OpenTK.Tests/Assertions.fs
+++ b/tests/OpenTK.Tests/Assertions.fs
@@ -9,7 +9,7 @@ open OpenTK
 [<AutoOpen>]
 module private AssertHelpers =
     [<Literal>]
-    let private BitAccuracy = 10
+    let private BitAccuracy = 13
 
     let approxEq a b = MathHelper.ApproximatelyEqual(a,b,BitAccuracy)
 

--- a/tests/OpenTK.Tests/Generators.fs
+++ b/tests/OpenTK.Tests/Generators.fs
@@ -22,18 +22,21 @@ module private Generators =
         singleArb
         |> Gen.two
         |> Gen.map Vector2
+        |> Gen.filter (fun v -> not <| (Single.IsNaN v.Length || Single.IsInfinity v.Length ))
         |> Arb.fromGen
 
     let vec3 =
         singleArb
         |> Gen.three
         |> Gen.map Vector3
+        |> Gen.filter (fun v -> not <| (Single.IsNaN v.Length || Single.IsInfinity v.Length ))
         |> Arb.fromGen
 
     let vec4 =
         singleArb
         |> Gen.four
         |> Gen.map Vector4
+        |> Gen.filter (fun v -> not <| (Single.IsNaN v.Length || Single.IsInfinity v.Length ))
         |> Arb.fromGen
 
     let quat =

--- a/tests/OpenTK.Tests/Vector2Tests.fs
+++ b/tests/OpenTK.Tests/Vector2Tests.fs
@@ -463,93 +463,98 @@ module Vector2 =
             Assert.ApproximatelyEqual(norm, Vector2.NormalizeFast(a));
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    module ``Magnitude min and max`` =
+        //
+        [<Property>]
+        let ``MagnitudeMin selects the vector with equal or lesser magnitude given two vectors`` (v1 : Vector2, v2: Vector2) =
+            let l1 = v1.LengthSquared
+            let l2 = v2.LengthSquared
+
+            let vMin = Vector2.MagnitudeMin(v1, v2)
+
+            if vMin = v1 then
+                let v1ShorterThanv2 = l1 < l2
+                Assert.True(v1ShorterThanv2)
+            else
+                let v2ShorterThanOrEqualTov1 = l2 <= l1
+                Assert.True(v2ShorterThanOrEqualTov1)
+
+        [<Property>]
+        let ``MagnitudeMax selects the vector with equal or greater magnitude given two vectors`` (v1 : Vector2, v2: Vector2) =
+            let l1 = v1.LengthSquared
+            let l2 = v2.LengthSquared
+
+            let vMin = Vector2.MagnitudeMax(v1, v2)
+
+            if vMin = v1 then
+                let v1LongerThanOrEqualTov2 = l1 >= l2
+                Assert.True(v1LongerThanOrEqualTov2)
+            else
+                let v2LongerThanv1 = l2 > l1
+                Assert.True(v2LongerThanv1)
+
+        [<Property>]
+        let ``MagnitudeMin by reference selects the vector with equal or lesser magnitude given two vectors`` (v1 : Vector2, v2: Vector2) =
+            let l1 = v1.LengthSquared
+            let l2 = v2.LengthSquared
+
+            let vMin = Vector2.MagnitudeMin(ref v1, ref v2)
+
+            if vMin = v1 then
+                let v1ShorterThanv2 = l1 < l2
+                Assert.True(v1ShorterThanv2)
+            else
+                let v2ShorterThanOrEqualTov1 = l2 <= l1
+                Assert.True(v2ShorterThanOrEqualTov1)
+
+        [<Property>]
+        let ``MagnitudeMax by reference selects the vector with equal greater magnitude given two vectors`` (v1 : Vector2, v2: Vector2) =
+            let l1 = v1.LengthSquared
+            let l2 = v2.LengthSquared
+
+            let vMin = Vector2.MagnitudeMax(ref v1, ref v2)
+
+            if vMin = v1 then
+                let v1LongerThanOrEqualTov2 = l1 >= l2
+                Assert.True(v1LongerThanOrEqualTov2)
+            else
+                let v2LongerThanv1 = l2 > l1
+                Assert.True(v2LongerThanv1)
+
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Component min and max`` =
         //
         [<Property>]
-        let ``ComponentMin produces a new vector from the smallest components of the given vectors`` (x, y, u, w) =
-            let v1 = Vector2(x, y)
-            let v2 = Vector2(u, w)
-
+        let ``ComponentMin creates a new vector from the smallest components of given vectors`` (v1 : Vector2, v2: Vector2) =
             let vMin = Vector2.ComponentMin(v1, v2)
+            let isComponentSmallest smallComp comp1 comp2 = smallComp <= comp1 && smallComp <= comp2
 
-            Assert.True(vMin.X <= v1.X)
-            Assert.True(vMin.X <= v2.X)
-
-            Assert.True(vMin.Y <= v1.Y)
-            Assert.True(vMin.Y <= v2.Y)
+            Assert.True(isComponentSmallest vMin.X v1.X v2.X)
+            Assert.True(isComponentSmallest vMin.Y v1.Y v2.Y)
 
         [<Property>]
-        let ``ComponentMax produces a new vector from the largest components of the given vectors`` (x, y, u, w) =
-            let v1 = Vector2(x, y)
-            let v2 = Vector2(u, w)
-
+        let ``ComponentMax creates a new vector from the greatest components of given vectors`` (v1 : Vector2, v2: Vector2) =
             let vMax = Vector2.ComponentMax(v1, v2)
+            let isComponentLargest largeComp comp1 comp2 = largeComp >= comp1 && largeComp >= comp2
 
-            Assert.True(vMax.X >= v1.X)
-            Assert.True(vMax.X >= v2.X)
-
-            Assert.True(vMax.Y >= v1.Y)
-            Assert.True(vMax.Y >= v2.Y)
+            Assert.True(isComponentLargest vMax.X v1.X v2.X)
+            Assert.True(isComponentLargest vMax.Y v1.Y v2.Y)
 
         [<Property>]
-        let ``ComponentMin by reference produces a new vector from the smallest components of the given vectors`` (x, y, u, w) =
-            let v1 = Vector2(x, y)
-            let v2 = Vector2(u, w)
-
+        let ``ComponentMin by reference creates a new vector from the smallest components of given vectors`` (v1 : Vector2, v2: Vector2) =
             let vMin = Vector2.ComponentMin(ref v1, ref v2)
+            let isComponentSmallest smallComp comp1 comp2 = smallComp <= comp1 && smallComp <= comp2
 
-            Assert.True(vMin.X <= v1.X)
-            Assert.True(vMin.X <= v2.X)
-
-            Assert.True(vMin.Y <= v1.Y)
-            Assert.True(vMin.Y <= v2.Y)
+            Assert.True(isComponentSmallest vMin.X v1.X v2.X)
+            Assert.True(isComponentSmallest vMin.Y v1.Y v2.Y)
 
         [<Property>]
-        let ``ComponentMax by reference produces a new vector from the largest components of the given vectors`` (x, y, u, w) =
-            let v1 = Vector2(x, y)
-            let v2 = Vector2(u, w)
-
+        let ``ComponentMax by reference creates a new vector from the greatest components of given vectors`` (v1 : Vector2, v2: Vector2) =
             let vMax = Vector2.ComponentMax(ref v1, ref v2)
+            let isComponentLargest largeComp comp1 comp2 = largeComp >= comp1 && largeComp >= comp2
 
-            Assert.True(vMax.X >= v1.X)
-            Assert.True(vMax.X >= v2.X)
-
-            Assert.True(vMax.Y >= v1.Y)
-            Assert.True(vMax.Y >= v2.Y)
-
-        [<Property>]
-        let ``Min selects the vector with lesser magnitude given two vectors`` (x, y, u, w) =
-            let v1 = Vector2(x, y)
-            let v2 = Vector2(u, w)
-
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
-
-            let vMin = Vector2.Min(v1, v2)
-
-            if l1 < l2 then
-                let equalsFirst = vMin = v1
-                Assert.True(equalsFirst)
-            else
-                let equalsLast = vMin = v2
-                Assert.True(equalsLast)
-
-        [<Property>]
-        let ``Max selects the vector with greater magnitude given two vectors`` (x, y, u, w) =
-            let v1 = Vector2(x, y)
-            let v2 = Vector2(u, w)
-
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
-
-            let vMin = Vector2.Max(v1, v2)
-
-            if l1 >= l2 then
-                let equalsFirst = vMin = v1
-                Assert.True(equalsFirst)
-            else
-                let equalsLast = vMin = v2
-                Assert.True(equalsLast)
+            Assert.True(isComponentLargest vMax.X v1.X v2.X)
+            Assert.True(isComponentLargest vMax.Y v1.Y v2.Y)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Transformation =

--- a/tests/OpenTK.Tests/Vector3Tests.fs
+++ b/tests/OpenTK.Tests/Vector3Tests.fs
@@ -528,105 +528,102 @@ module Vector3 =
             Assert.Equal(cross, vRes)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    module ``Magnitude min and max`` =
+        //
+        [<Property>]
+        let ``MagnitudeMin selects the vector with equal or lesser magnitude given two vectors`` (v1 : Vector3, v2: Vector3) =
+            let l1 = v1.LengthSquared
+            let l2 = v2.LengthSquared
+
+            let vMin = Vector3.MagnitudeMin(v1, v2)
+
+            if vMin = v1 then
+                let v1ShorterThanv2 = l1 < l2
+                Assert.True(v1ShorterThanv2)
+            else
+                let v2ShorterThanOrEqualTov1 = l2 <= l1
+                Assert.True(v2ShorterThanOrEqualTov1)
+
+        [<Property>]
+        let ``MagnitudeMax selects the vector with equal or greater magnitude given two vectors`` (v1 : Vector3, v2: Vector3) =
+            let l1 = v1.LengthSquared
+            let l2 = v2.LengthSquared
+
+            let vMin = Vector3.MagnitudeMax(v1, v2)
+
+            if vMin = v1 then
+                let v1LongerThanOrEqualTov2 = l1 >= l2
+                Assert.True(v1LongerThanOrEqualTov2)
+            else
+                let v2LongerThanv1 = l2 > l1
+                Assert.True(v2LongerThanv1)
+
+        [<Property>]
+        let ``MagnitudeMin by reference selects the vector with equal or lesser magnitude given two vectors`` (v1 : Vector3, v2: Vector3) =
+            let l1 = v1.LengthSquared
+            let l2 = v2.LengthSquared
+
+            let vMin = Vector3.MagnitudeMin(ref v1, ref v2)
+
+            if vMin = v1 then
+                let v1ShorterThanv2 = l1 < l2
+                Assert.True(v1ShorterThanv2)
+            else
+                let v2ShorterThanOrEqualTov1 = l2 <= l1
+                Assert.True(v2ShorterThanOrEqualTov1)
+
+        [<Property>]
+        let ``MagnitudeMax by reference selects the vector with equal or greater magnitude given two vectors`` (v1 : Vector3, v2: Vector3) =
+            let l1 = v1.LengthSquared
+            let l2 = v2.LengthSquared
+
+            let vMin = Vector3.MagnitudeMax(ref v1, ref v2)
+
+            if vMin = v1 then
+                let v1LongerThanOrEqualTov2 = l1 >= l2
+                Assert.True(v1LongerThanOrEqualTov2)
+            else
+                let v2LongerThanv1 = l2 > l1
+                Assert.True(v2LongerThanv1)
+
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Component min and max`` =
         //
         [<Property>]
-        let ``ComponentMin produces a new vector from the smallest components of the given vectors`` (x, y, z, u, w, q) =
-            let v1 = Vector3(x, y, z)
-            let v2 = Vector3(u, w, q)
-
+        let ``ComponentMin creates a new vector from the smallest components of given vectors`` (v1 : Vector3, v2: Vector3) =
             let vMin = Vector3.ComponentMin(v1, v2)
+            let isComponentSmallest smallComp comp1 comp2 = smallComp <= comp1 && smallComp <= comp2
 
-            Assert.True(vMin.X <= v1.X)
-            Assert.True(vMin.X <= v2.X)
-
-            Assert.True(vMin.Y <= v1.Y)
-            Assert.True(vMin.Y <= v2.Y)
-
-            Assert.True(vMin.Z <= v1.Z)
-            Assert.True(vMin.Z <= v2.Z)
+            Assert.True(isComponentSmallest vMin.X v1.X v2.X)
+            Assert.True(isComponentSmallest vMin.Y v1.Y v2.Y)
+            Assert.True(isComponentSmallest vMin.Z v1.Z v2.Z)
 
         [<Property>]
-        let ``ComponentMax producing a new vector from the largest components of the given vectors`` (x, y, z, u, w, q) =
-            let v1 = Vector3(x, y, z)
-            let v2 = Vector3(u, w, q)
-
+        let ``ComponentMax creates a new vector from the greatest components of given vectors`` (v1 : Vector3, v2: Vector3) =
             let vMax = Vector3.ComponentMax(v1, v2)
+            let isComponentLargest largeComp comp1 comp2 = largeComp >= comp1 && largeComp >= comp2
 
-            Assert.True(vMax.X >= v1.X)
-            Assert.True(vMax.X >= v2.X)
-
-            Assert.True(vMax.Y >= v1.Y)
-            Assert.True(vMax.Y >= v2.Y)
-
-            Assert.True(vMax.Z >= v1.Z)
-            Assert.True(vMax.Z >= v2.Z)
+            Assert.True(isComponentLargest vMax.X v1.X v2.X)
+            Assert.True(isComponentLargest vMax.Y v1.Y v2.Y)
+            Assert.True(isComponentLargest vMax.Z v1.Z v2.Z)
 
         [<Property>]
-        let ``ComponentMin by reference produces a new vector from the smallest components of the given vectors`` (x, y, z, u, w, q) =
-            let v1 = Vector3(x, y, z)
-            let v2 = Vector3(u, w, q)
-
+        let ``ComponentMin by reference creates a new vector from the smallest components of given vectors`` (v1 : Vector3, v2: Vector3) =
             let vMin = Vector3.ComponentMin(ref v1, ref v2)
+            let isComponentSmallest smallComp comp1 comp2 = smallComp <= comp1 && smallComp <= comp2
 
-            Assert.True(vMin.X <= v1.X)
-            Assert.True(vMin.X <= v2.X)
-
-            Assert.True(vMin.Y <= v1.Y)
-            Assert.True(vMin.Y <= v2.Y)
-
-            Assert.True(vMin.Z <= v1.Z)
-            Assert.True(vMin.Z <= v2.Z)
+            Assert.True(isComponentSmallest vMin.X v1.X v2.X)
+            Assert.True(isComponentSmallest vMin.Y v1.Y v2.Y)
+            Assert.True(isComponentSmallest vMin.Z v1.Z v2.Z)
 
         [<Property>]
-        let ``ComponentMax produces a new vector from the smallest components of the given vectors`` (x, y, z, u, w, q) =
-            let v1 = Vector3(x, y, z)
-            let v2 = Vector3(u, w, q)
-
+        let ``ComponentMax by reference creates a new vector from the greatest components of given vectors`` (v1 : Vector3, v2: Vector3) =
             let vMax = Vector3.ComponentMax(ref v1, ref v2)
+            let isComponentLargest largeComp comp1 comp2 = largeComp >= comp1 && largeComp >= comp2
 
-            Assert.True(vMax.X >= v1.X)
-            Assert.True(vMax.X >= v2.X)
-
-            Assert.True(vMax.Y >= v1.Y)
-            Assert.True(vMax.Y >= v2.Y)
-
-            Assert.True(vMax.Z >= v1.Z)
-            Assert.True(vMax.Z >= v2.Z)
-
-        [<Property>]
-        let ``Min selects the vector with lesser magnitude given two vectors`` (x, y, z, u, w, q) =
-            let v1 = Vector3(x, y, z)
-            let v2 = Vector3(u, w, q)
-
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
-
-            let vMin = Vector3.Min(v1, v2)
-
-            if l1 < l2 then
-                let equalsFirst = vMin = v1
-                Assert.True(equalsFirst)
-            else
-                let equalsLast = vMin = v2
-                Assert.True(equalsLast)
-
-        [<Property>]
-        let ``Max selects the vector with greater magnitude given two vectors`` (x, y, z, u, w, q) =
-            let v1 = Vector3(x, y, z)
-            let v2 = Vector3(u, w, q)
-
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
-
-            let vMin = Vector3.Max(v1, v2)
-
-            if l1 >= l2 then
-                let equalsFirst = vMin = v1
-                Assert.True(equalsFirst)
-            else
-                let equalsLast = vMin = v2
-                Assert.True(equalsLast)
+            Assert.True(isComponentLargest vMax.X v1.X v2.X)
+            Assert.True(isComponentLargest vMax.Y v1.Y v2.Y)
+            Assert.True(isComponentLargest vMax.Z v1.Z v2.Z)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Clamping =

--- a/tests/OpenTK.Tests/Vector4Tests.fs
+++ b/tests/OpenTK.Tests/Vector4Tests.fs
@@ -799,12 +799,12 @@ module Vector4 =
         //
         [<Property>]
         let ``Clamping one vector between two other vectors clamps all components between corresponding components`` (a : Vector4, b : Vector4, w : Vector4) =
-            let res = Vector4.Clamp(w, a, b)
-
             let expX = if w.X < a.X then a.X else if w.X > b.X then b.X else w.X
             let expY = if w.Y < a.Y then a.Y else if w.Y > b.Y then b.Y else w.Y
             let expZ = if w.Z < a.Z then a.Z else if w.Z > b.Z then b.Z else w.Z
             let expW = if w.W < a.W then a.W else if w.W > b.W then b.W else w.W
+
+            let res = Vector4.Clamp(w, a, b)
 
             Assert.Equal(expX, res.X)
             Assert.Equal(expY, res.Y)
@@ -812,13 +812,13 @@ module Vector4 =
             Assert.Equal(expW, res.W)
 
         [<Property>]
-        let ``Clamping one vector between two other vectors by reference clamps all components`` (a : Vector4, b : Vector4, w : Vector4) =
-            let res = Vector4.Clamp(ref w, ref a, ref b)
-
+        let ``Clamping one vector between two other vectors by reference clamps all components between corresponding components`` (a : Vector4, b : Vector4, w : Vector4) =
             let expX = if w.X < a.X then a.X else if w.X > b.X then b.X else w.X
             let expY = if w.Y < a.Y then a.Y else if w.Y > b.Y then b.Y else w.Y
             let expZ = if w.Z < a.Z then a.Z else if w.Z > b.Z then b.Z else w.Z
             let expW = if w.W < a.W then a.W else if w.W > b.W then b.W else w.W
+
+            let res = Vector4.Clamp(ref w, ref a, ref b)
 
             Assert.Equal(expX, res.X)
             Assert.Equal(expY, res.Y)

--- a/tests/OpenTK.Tests/Vector4Tests.fs
+++ b/tests/OpenTK.Tests/Vector4Tests.fs
@@ -705,8 +705,8 @@ module Vector4 =
                 let v1ShorterThanv2 = l1 < l2
                 Assert.True(v1ShorterThanv2)
             else
-                let v2ShorterThanv1 = l2 < l1
-                Assert.True(v2ShorterThanv1)
+                let v2ShorterThanOrEqualTov1 = l2 <= l1
+                Assert.True(v2ShorterThanOrEqualTov1)
 
         [<Property>]
         let ``MagnitudeMax selects the vector with equal or greater magnitude given two vectors`` (v1 : Vector4, v2: Vector4) =

--- a/tests/OpenTK.Tests/Vector4Tests.fs
+++ b/tests/OpenTK.Tests/Vector4Tests.fs
@@ -692,17 +692,14 @@ module Vector4 =
             Assert.Equal(dot, vRes)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
-    module ``Component min and max`` =
+    module ``Magnitude min and max`` =
         //
         [<Property>]
-        let ``Min selects the vector with lesser magnitude given two vectors`` (x, y, z, w, a, b, c, d) =
-            let v1 = Vector4(x, y, z, w)
-            let v2 = Vector4(a, b, c, d)
-
+        let ``MagnitudeMin selects the vector with equal or lesser magnitude given two vectors`` (v1 : Vector4, v2: Vector4) =
             let l1 = v1.LengthSquared
             let l2 = v2.LengthSquared
 
-            let vMin = Vector4.Min(v1, v2)
+            let vMin = Vector4.MagnitudeMin(v1, v2)
 
             if vMin = v1 then
                 let v1ShorterThanv2 = l1 < l2
@@ -712,14 +709,11 @@ module Vector4 =
                 Assert.True(v2ShorterThanv1)
 
         [<Property>]
-        let ``Max selects the vector with greater magnitude given two vectors`` (x, y, z, w, a, b, c, d) =
-            let v1 = Vector4(x, y, z, w)
-            let v2 = Vector4(a, b, c, d)
-
+        let ``MagnitudeMax selects the vector with equal or greater magnitude given two vectors`` (v1 : Vector4, v2: Vector4) =
             let l1 = v1.LengthSquared
             let l2 = v2.LengthSquared
 
-            let vMin = Vector4.Max(v1, v2)
+            let vMin = Vector4.MagnitudeMax(v1, v2)
 
             if vMin = v1 then
                 let v1LongerThanOrEqualTov2 = l1 >= l2
@@ -727,6 +721,78 @@ module Vector4 =
             else
                 let v2LongerThanv1 = l2 > l1
                 Assert.True(v2LongerThanv1)
+
+        [<Property>]
+        let ``MagnitudeMin by reference selects the vector with equal or lesser magnitude given two vectors`` (v1 : Vector4, v2: Vector4) =
+            let l1 = v1.LengthSquared
+            let l2 = v2.LengthSquared
+
+            let vMin = Vector4.MagnitudeMin(ref v1, ref v2)
+
+            if vMin = v1 then
+                let v1ShorterThanv2 = l1 < l2
+                Assert.True(v1ShorterThanv2)
+            else
+                let v2ShorterThanOrEqualTov1 = l2 <= l1
+                Assert.True(v2ShorterThanOrEqualTov1)
+
+        [<Property>]
+        let ``MagnitudeMax by reference selects the vector with equal or greater magnitude given two vectors`` (v1 : Vector4, v2: Vector4) =
+            let l1 = v1.LengthSquared
+            let l2 = v2.LengthSquared
+
+            let vMin = Vector4.MagnitudeMax(ref v1, ref v2)
+
+            if vMin = v1 then
+                let v1LongerThanOrEqualTov2 = l1 >= l2
+                Assert.True(v1LongerThanOrEqualTov2)
+            else
+                let v2LongerThanv1 = l2 > l1
+                Assert.True(v2LongerThanv1)
+
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    module ``Component min and max`` =
+        //
+        [<Property>]
+        let ``ComponentMin creates a new vector from the smallest components of given vectors`` (v1 : Vector4, v2: Vector4) =
+            let vMin = Vector4.ComponentMin(v1, v2)
+            let isComponentSmallest smallComp comp1 comp2 = smallComp <= comp1 && smallComp <= comp2
+
+            Assert.True(isComponentSmallest vMin.X v1.X v2.X)
+            Assert.True(isComponentSmallest vMin.Y v1.Y v2.Y)
+            Assert.True(isComponentSmallest vMin.Z v1.Z v2.Z)
+            Assert.True(isComponentSmallest vMin.W v1.W v2.W)
+
+        [<Property>]
+        let ``ComponentMax creates a new vector from the greatest components of given vectors`` (v1 : Vector4, v2: Vector4) =
+            let vMax = Vector4.ComponentMax(v1, v2)
+            let isComponentLargest largeComp comp1 comp2 = largeComp >= comp1 && largeComp >= comp2
+
+            Assert.True(isComponentLargest vMax.X v1.X v2.X)
+            Assert.True(isComponentLargest vMax.Y v1.Y v2.Y)
+            Assert.True(isComponentLargest vMax.Z v1.Z v2.Z)
+            Assert.True(isComponentLargest vMax.W v1.W v2.W)
+
+        [<Property>]
+        let ``ComponentMin by reference creates a new vector from the smallest components of given vectors`` (v1 : Vector4, v2: Vector4) =
+            let vMin = Vector4.ComponentMin(ref v1, ref v2)
+            let isComponentSmallest smallComp comp1 comp2 = smallComp <= comp1 && smallComp <= comp2
+
+            Assert.True(isComponentSmallest vMin.X v1.X v2.X)
+            Assert.True(isComponentSmallest vMin.Y v1.Y v2.Y)
+            Assert.True(isComponentSmallest vMin.Z v1.Z v2.Z)
+            Assert.True(isComponentSmallest vMin.W v1.W v2.W)
+
+        [<Property>]
+        let ``ComponentMax by reference creates a new vector from the greatest components of given vectors`` (v1 : Vector4, v2: Vector4) =
+            let vMax = Vector4.ComponentMax(ref v1, ref v2)
+            let isComponentLargest largeComp comp1 comp2 = largeComp >= comp1 && largeComp >= comp2
+
+            Assert.True(isComponentLargest vMax.X v1.X v2.X)
+            Assert.True(isComponentLargest vMax.Y v1.Y v2.Y)
+            Assert.True(isComponentLargest vMax.Z v1.Z v2.Z)
+            Assert.True(isComponentLargest vMax.W v1.W v2.W)
+
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Clamping =


### PR DESCRIPTION
This PR marks the Min/Max methods in all vector classes as obsolete, and implements replacement functionality in all vector classes. The existing methods had ambiguous names and differing implementations. 

It also implements full testing for all affected methods, and removes old tests for the now obsolete methods. In addition, the vector generation for tests are now restricted to "valid" vectors, where the length of a vector does not equate NaN or Infinity.

Furthermore, the bit sensitivity for unit testing has been decreased even further.