### PR TITLE
Add new approximation algorithm and replace current usages in tests

### DIFF
--- a/src/OpenTK/Math/MathHelper.cs
+++ b/src/OpenTK/Math/MathHelper.cs
@@ -3,13 +3,14 @@
  * Copyright (c) 2006-2008 the OpenTK Team.
  * This notice may not be removed from any source distribution.
  * See license.txt for licensing detailed licensing details.
- * 
+ *
  * Contributions by Andy Gill, James Talton and Georg Wächter.
  */
 #endregion
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace OpenTK
@@ -353,6 +354,73 @@ namespace OpenTK
 			long intDiff = Math.Abs(aInt - bInt);
 			return intDiff <= (1 << maxDeltaBits);
 		}
+
+        /// <summary>
+        /// Approximates double-precision floating point equality by an epsilon (maximum error) value.
+        /// This method is designed as a "fits-all" solution and attempts to handle as many cases as possible.
+        /// </summary>
+        /// <param name="a">The first float.</param>
+        /// <param name="b">The second float.</param>
+        /// <param name="epsilon">The maximum error between the two.</param>
+        /// <returns><value>true</value> if the values are approximately equal within the error margin; otherwise, <value>false</value>.</returns>
+        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
+        public static bool ApproximatelyEqualEpsilon(double a, double b, double epsilon)
+        {
+            const double doubleNormal = (1L << 52) * double.Epsilon;
+            double absA = Math.Abs(a);
+            double absB = Math.Abs(b);
+            double diff = Math.Abs(a - b);
+
+            if (a == b)
+            {
+                // Shortcut, handles infinities
+                return true;
+            }
+
+            if (a == 0.0f || b == 0.0f || diff < doubleNormal)
+            {
+                // a or b is zero, or both are extremely close to it.
+                // relative error is less meaningful here
+                return diff < (epsilon * doubleNormal);
+            }
+
+            // use relative error
+            return diff / Math.Min((absA + absB), double.MaxValue) < epsilon;
+        }
+
+        /// <summary>
+        /// Approximates single-precision floating point equality by an epsilon (maximum error) value.
+        /// This method is designed as a "fits-all" solution and attempts to handle as many cases as possible.
+        /// </summary>
+        /// <param name="a">The first float.</param>
+        /// <param name="b">The second float.</param>
+        /// <param name="epsilon">The maximum error between the two.</param>
+        /// <returns><value>true</value> if the values are approximately equal within the error margin; otherwise, <value>false</value>.</returns>
+        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
+        public static bool ApproximatelyEqualEpsilon(float a, float b, float epsilon)
+        {
+            const float floatNormal = (1 << 23) * float.Epsilon;
+            float absA = Math.Abs(a);
+            float absB = Math.Abs(b);
+            float diff = Math.Abs(a - b);
+
+            if (a == b)
+            {
+                // Shortcut, handles infinities
+                return true;
+            }
+
+            if (a == 0.0f || b == 0.0f || diff < floatNormal)
+            {
+                // a or b is zero, or both are extremely close to it.
+                // relative error is less meaningful here
+                return diff < (epsilon * floatNormal);
+            }
+
+            // use relative error
+            float relativeError = diff / Math.Min((absA + absB), float.MaxValue);
+            return relativeError < epsilon;
+        }
 
 		#endregion
 

--- a/src/OpenTK/Math/MathHelper.cs
+++ b/src/OpenTK/Math/MathHelper.cs
@@ -422,6 +422,50 @@ namespace OpenTK
             return relativeError < epsilon;
         }
 
+        /// <summary>
+        /// Approximates equivalence between two single-precision floating-point numbers on a direct human scale.
+        /// It is important to note that this does not approximate equality - instead, it merely checks whether or not
+        /// two numbers could be considered equivalent to each other within a certain tolerance.
+        /// </summary>
+        /// <param name="a">The first value to compare.</param>
+        /// <param name="b">The second value to compare·</param>
+        /// <param name="tolerance">The tolerance within which the two values would be considered equivalent.</param>
+        /// <returns>Whether or not the values can be considered equivalent within the tolerance.</returns>
+        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
+        public static bool ApproximatelyEquivalent(float a, float b, float tolerance)
+        {
+            if (a == b)
+            {
+                // Early bailout, handles infinities
+                return true;
+            }
+
+            float diff = Math.Abs(a - b);
+            return diff < tolerance;
+        }
+
+        /// <summary>
+        /// Approximates equivalence between two double-precision floating-point numbers on a direct human scale.
+        /// It is important to note that this does not approximate equality - instead, it merely checks whether or not
+        /// two numbers could be considered equivalent to each other within a certain tolerance.
+        /// </summary>
+        /// <param name="a">The first value to compare.</param>
+        /// <param name="b">The second value to compare·</param>
+        /// <param name="tolerance">The tolerance within which the two values would be considered equivalent.</param>
+        /// <returns>Whether or not the values can be considered equivalent within the tolerance.</returns>
+        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
+        public static bool ApproximatelyEquivalent(double a, double b, double tolerance)
+        {
+            if (a == b)
+            {
+                // Early bailout, handles infinities
+                return true;
+            }
+
+            double diff = Math.Abs(a - b);
+            return diff < tolerance;
+        }
+
 		#endregion
 
 		#endregion

--- a/src/OpenTK/Math/MathHelper.cs
+++ b/src/OpenTK/Math/MathHelper.cs
@@ -425,7 +425,8 @@ namespace OpenTK
         /// <summary>
         /// Approximates equivalence between two single-precision floating-point numbers on a direct human scale.
         /// It is important to note that this does not approximate equality - instead, it merely checks whether or not
-        /// two numbers could be considered equivalent to each other within a certain tolerance.
+        /// two numbers could be considered equivalent to each other within a certain tolerance. The tolerance is
+        /// inclusive.
         /// </summary>
         /// <param name="a">The first value to compare.</param>
         /// <param name="b">The second value to compare·</param>
@@ -441,13 +442,14 @@ namespace OpenTK
             }
 
             float diff = Math.Abs(a - b);
-            return diff < tolerance;
+            return diff <= tolerance;
         }
 
         /// <summary>
         /// Approximates equivalence between two double-precision floating-point numbers on a direct human scale.
         /// It is important to note that this does not approximate equality - instead, it merely checks whether or not
-        /// two numbers could be considered equivalent to each other within a certain tolerance.
+        /// two numbers could be considered equivalent to each other within a certain tolerance. The tolerance is
+        /// inclusive.
         /// </summary>
         /// <param name="a">The first value to compare.</param>
         /// <param name="b">The second value to compare·</param>
@@ -463,7 +465,7 @@ namespace OpenTK
             }
 
             double diff = Math.Abs(a - b);
-            return diff < tolerance;
+            return diff <= tolerance;
         }
 
 		#endregion

--- a/tests/OpenTK.Tests/Assertions.fs
+++ b/tests/OpenTK.Tests/Assertions.fs
@@ -12,11 +12,11 @@ module private AssertHelpers =
     let private BitAccuracy = 16
 
     [<Literal>]
-    let private EquivalenceTolerance = 0.0001f
+    let private EquivalenceTolerance = 0.00005f
 
     let approxEq a b = MathHelper.ApproximatelyEquivalent(a, b, EquivalenceTolerance)
-    //let approxEq a b = MathHelper.ApproximatelyEqual(a,b,BitAccuracy)
-    //let approxEq a b = MathHelper.ApproximatelyEqualEpsilon(a,b,0.0001f)
+
+    let approxEqDelta a b = MathHelper.ApproximatelyEqual(a,b,BitAccuracy)
 
     let approxEqSingleEpsilon a b = MathHelper.ApproximatelyEqualEpsilon(a, b, 0.00001f)
     let approxEqDoubleEpsilon a b = MathHelper.ApproximatelyEqualEpsilon(a, b, 0.00001)
@@ -32,17 +32,17 @@ module private AssertHelpers =
 [<Sealed>]
 type internal Assert =
 
-    static member ApproximatelyEqual(a : Vector2,b : Vector2) =
+    static member ApproximatelyEquivalent(a : Vector2,b : Vector2) =
         if not <| approxEq a.X b.X && approxEq a.Y b.Y then raise <| new Xunit.Sdk.EqualException(a,b)
 
-    static member ApproximatelyEqual(a : Vector3,b : Vector3) =
+    static member ApproximatelyEquivalent(a : Vector3,b : Vector3) =
         if not <| approxEq a.X b.X && approxEq a.Y b.Y && approxEq a.Z b.Z then raise <| new Xunit.Sdk.EqualException(a,b)
 
-    static member ApproximatelyEqual(a : Vector4,b : Vector4) =
+    static member ApproximatelyEquivalent(a : Vector4,b : Vector4) =
         if not <| approxEq a.X b.X && approxEq a.Y b.Y && approxEq a.Z b.Z && approxEq a.W b.W then
             raise <| new Xunit.Sdk.EqualException(a,b)
 
-    static member ApproximatelyEqual(a : float32,b : float32) =
+    static member ApproximatelyEquivalent(a : float32,b : float32) =
         if not <| approxEq a b then raise <| new Xunit.Sdk.EqualException(a,b)
 
 

--- a/tests/OpenTK.Tests/Assertions.fs
+++ b/tests/OpenTK.Tests/Assertions.fs
@@ -9,9 +9,19 @@ open OpenTK
 [<AutoOpen>]
 module private AssertHelpers =
     [<Literal>]
-    let private BitAccuracy = 13
+    let private BitAccuracy = 16
 
-    let approxEq a b = MathHelper.ApproximatelyEqual(a,b,BitAccuracy)
+    //let approxEq a b = MathHelper.ApproximatelyEqual(a,b,BitAccuracy)
+    let approxEq a b = MathHelper.ApproximatelyEqualEpsilon(a,b,0.0001f)
+    let approxEqSingleEpsilon a b = MathHelper.ApproximatelyEqualEpsilon(a, b, 0.00001f)
+    let approxEqDoubleEpsilon a b = MathHelper.ApproximatelyEqualEpsilon(a, b, 0.00001)
+
+    let approxEqSingleEpsilonWithError (a, b, c : float32) = MathHelper.ApproximatelyEqualEpsilon(a, b, c)
+    let approxEqDoubleEpsilonWithError (a, b, c : float) = MathHelper.ApproximatelyEqualEpsilon(a, b, c)
+
+    let anyZero2 (a : Vector2) = (approxEq a.X 0.0f || approxEq a.Y 0.0f)
+    let anyZero3 (a : Vector3) = (approxEq a.X 0.0f || approxEq a.Y 0.0f || approxEq a.Z 0.0f)
+    let anyZero4 (a : Vector4) = (approxEq a.X 0.0f || approxEq a.Y 0.0f || approxEq a.Z 0.0f || approxEq a.W 0.0f)
 
 /// We use a full type here instead of a module, as the overloading semantics are more suitable for our desired goal.
 [<Sealed>]
@@ -30,5 +40,32 @@ type internal Assert =
     static member ApproximatelyEqual(a : float32,b : float32) =
         if not <| approxEq a b then raise <| new Xunit.Sdk.EqualException(a,b)
 
+
+    static member ApproximatelyEqualEpsilon(a : float32, b : float32) =
+        if not <| approxEqSingleEpsilon a b then raise <| new Xunit.Sdk.EqualException(a,b)
+
+    static member ApproximatelyEqualEpsilon(a : float32, b : float32, c : float32) =
+        if not <| approxEqSingleEpsilonWithError(a, b, c) then raise <| new Xunit.Sdk.EqualException(a,b)
+
+
+    static member ApproximatelyEqualEpsilon(a : float, b : float) =
+        if not <| approxEqDoubleEpsilon a b then raise <| new Xunit.Sdk.EqualException(a,b)
+
+    static member ApproximatelyEqualEpsilon(a : float, b : float, c : float) =
+        if not <| approxEqDoubleEpsilonWithError(a, b, c) then raise <| new Xunit.Sdk.EqualException(a,b)
+
+
+    static member NotApproximatelyEqualEpsilon(a : float32, b : float32) =
+        if approxEqSingleEpsilon a b then raise <| new Xunit.Sdk.EqualException(a,b)
+
+    static member NotApproximatelyEqualEpsilon(a : float32, b : float32, c : float32) =
+        if approxEqSingleEpsilonWithError(a, b, c) then raise <| new Xunit.Sdk.EqualException(a,b)
+
+
+    static member NotApproximatelyEqualEpsilon(a : float, b : float) =
+        if approxEqDoubleEpsilon a b then raise <| new Xunit.Sdk.EqualException(a,b)
+
+    static member NotApproximatelyEqualEpsilon(a : float, b : float, c : float) =
+        if approxEqDoubleEpsilonWithError(a, b, c) then raise <| new Xunit.Sdk.EqualException(a,b)
 
     static member ThrowsIndexExn(f:unit -> unit) = Assert.Throws<IndexOutOfRangeException>(f) |> ignore

--- a/tests/OpenTK.Tests/Assertions.fs
+++ b/tests/OpenTK.Tests/Assertions.fs
@@ -11,8 +11,13 @@ module private AssertHelpers =
     [<Literal>]
     let private BitAccuracy = 16
 
+    [<Literal>]
+    let private EquivalenceTolerance = 0.0001f
+
+    let approxEq a b = MathHelper.ApproximatelyEquivalent(a, b, EquivalenceTolerance)
     //let approxEq a b = MathHelper.ApproximatelyEqual(a,b,BitAccuracy)
-    let approxEq a b = MathHelper.ApproximatelyEqualEpsilon(a,b,0.0001f)
+    //let approxEq a b = MathHelper.ApproximatelyEqualEpsilon(a,b,0.0001f)
+
     let approxEqSingleEpsilon a b = MathHelper.ApproximatelyEqualEpsilon(a, b, 0.00001f)
     let approxEqDoubleEpsilon a b = MathHelper.ApproximatelyEqualEpsilon(a, b, 0.00001)
 

--- a/tests/OpenTK.Tests/MathHelperTests.fs
+++ b/tests/OpenTK.Tests/MathHelperTests.fs
@@ -60,69 +60,69 @@ module MathHelper =
         //
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for large positive values``() =
-            Assert.ApproximatelyEquivalentEpsilon(1000000.0f, 1000001.0f);
-            Assert.ApproximatelyEquivalentEpsilon(1000001.0f, 1000000.0f);
+            Assert.ApproximatelyEqualEpsilon(1000000.0f, 1000001.0f);
+            Assert.ApproximatelyEqualEpsilon(1000001.0f, 1000000.0f);
             Assert.NotApproximatelyEqualEpsilon(10000.0f, 10001.0f);
             Assert.NotApproximatelyEqualEpsilon(10001.0f, 10000.0f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for large negative values``() =
-            Assert.ApproximatelyEquivalentEpsilon(-1000000.0f, -1000001.0f);
-            Assert.ApproximatelyEquivalentEpsilon(-1000001.0f, -1000000.0f);
+            Assert.ApproximatelyEqualEpsilon(-1000000.0f, -1000001.0f);
+            Assert.ApproximatelyEqualEpsilon(-1000001.0f, -1000000.0f);
             Assert.NotApproximatelyEqualEpsilon(-10000.0f, -10001.0f);
             Assert.NotApproximatelyEqualEpsilon(-10001.0f, -10000.0f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for positive values around 1``() =
-            Assert.ApproximatelyEquivalentEpsilon(1.0000001f, 1.0000002f);
-            Assert.ApproximatelyEquivalentEpsilon(1.0000002f, 1.0000001f);
+            Assert.ApproximatelyEqualEpsilon(1.0000001f, 1.0000002f);
+            Assert.ApproximatelyEqualEpsilon(1.0000002f, 1.0000001f);
             Assert.NotApproximatelyEqualEpsilon(1.0002f, 1.0001f);
             Assert.NotApproximatelyEqualEpsilon(1.0001f, 1.0002f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for negative values around -1``() =
-            Assert.ApproximatelyEquivalentEpsilon(-1.000001f, -1.000002f);
-            Assert.ApproximatelyEquivalentEpsilon(-1.000002f, -1.000001f);
+            Assert.ApproximatelyEqualEpsilon(-1.000001f, -1.000002f);
+            Assert.ApproximatelyEqualEpsilon(-1.000002f, -1.000001f);
             Assert.NotApproximatelyEqualEpsilon(-1.0001f, -1.0002f);
             Assert.NotApproximatelyEqualEpsilon(-1.0002f, -1.0001f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for values between 1 and 0``() =
-            Assert.ApproximatelyEquivalentEpsilon(0.000000001000001f, 0.000000001000002f);
-            Assert.ApproximatelyEquivalentEpsilon(0.000000001000002f, 0.000000001000001f);
+            Assert.ApproximatelyEqualEpsilon(0.000000001000001f, 0.000000001000002f);
+            Assert.ApproximatelyEqualEpsilon(0.000000001000002f, 0.000000001000001f);
             Assert.NotApproximatelyEqualEpsilon(0.000000000001002f, 0.000000000001001f);
             Assert.NotApproximatelyEqualEpsilon(0.000000000001001f, 0.000000000001002f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for values between -1 and 0``() =
-            Assert.ApproximatelyEquivalentEpsilon(-0.000000001000001f, -0.000000001000002f);
-            Assert.ApproximatelyEquivalentEpsilon(-0.000000001000002f, -0.000000001000001f);
+            Assert.ApproximatelyEqualEpsilon(-0.000000001000001f, -0.000000001000002f);
+            Assert.ApproximatelyEqualEpsilon(-0.000000001000002f, -0.000000001000001f);
             Assert.NotApproximatelyEqualEpsilon(-0.000000000001002f, -0.000000000001001f);
             Assert.NotApproximatelyEqualEpsilon(-0.000000000001001f, -0.000000000001002f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for comparisons involving 0``() =
-            Assert.ApproximatelyEquivalentEpsilon(0.0f, 0.0f);
-            Assert.ApproximatelyEquivalentEpsilon(0.0f, -0.0f);
-            Assert.ApproximatelyEquivalentEpsilon(-0.0f, -0.0f);
+            Assert.ApproximatelyEqualEpsilon(0.0f, 0.0f);
+            Assert.ApproximatelyEqualEpsilon(0.0f, -0.0f);
+            Assert.ApproximatelyEqualEpsilon(-0.0f, -0.0f);
             Assert.NotApproximatelyEqualEpsilon(0.00000001f, 0.0f);
             Assert.NotApproximatelyEqualEpsilon(0.0f, 0.00000001f);
             Assert.NotApproximatelyEqualEpsilon(-0.00000001f, 0.0f);
             Assert.NotApproximatelyEqualEpsilon(0.0f, -0.00000001f);
 
-            Assert.ApproximatelyEquivalentEpsilon(0.0f, 1e-40f, 0.01f);
-            Assert.ApproximatelyEquivalentEpsilon(1e-40f, 0.0f, 0.01f);
+            Assert.ApproximatelyEqualEpsilon(0.0f, 1e-40f, 0.01f);
+            Assert.ApproximatelyEqualEpsilon(1e-40f, 0.0f, 0.01f);
             Assert.NotApproximatelyEqualEpsilon(1e-40f, 0.0f, 0.000001f);
             Assert.NotApproximatelyEqualEpsilon(0.0f, 1e-40f, 0.000001f);
 
-            Assert.ApproximatelyEquivalentEpsilon(0.0f, -1e-40f, 0.1f);
-            Assert.ApproximatelyEquivalentEpsilon(-1e-40f, 0.0f, 0.1f);
+            Assert.ApproximatelyEqualEpsilon(0.0f, -1e-40f, 0.1f);
+            Assert.ApproximatelyEqualEpsilon(-1e-40f, 0.0f, 0.1f);
             Assert.NotApproximatelyEqualEpsilon(-1e-40f, 0.0f, 0.00000001f);
             Assert.NotApproximatelyEqualEpsilon(0.0f, -1e-40f, 0.00000001f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for extreme values with overflow potential``() =
-            Assert.ApproximatelyEquivalentEpsilon(System.Single.MaxValue, System.Single.MaxValue);
+            Assert.ApproximatelyEqualEpsilon(System.Single.MaxValue, System.Single.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(System.Single.MaxValue, -System.Single.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(-System.Single.MaxValue, System.Single.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(System.Single.MaxValue, System.Single.MaxValue / 2.0f);
@@ -131,8 +131,8 @@ module MathHelper =
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for values involving infinities``() =
-            Assert.ApproximatelyEquivalentEpsilon(System.Single.PositiveInfinity, System.Single.PositiveInfinity);
-            Assert.ApproximatelyEquivalentEpsilon(System.Single.NegativeInfinity, System.Single.NegativeInfinity);
+            Assert.ApproximatelyEqualEpsilon(System.Single.PositiveInfinity, System.Single.PositiveInfinity);
+            Assert.ApproximatelyEqualEpsilon(System.Single.NegativeInfinity, System.Single.NegativeInfinity);
             Assert.NotApproximatelyEqualEpsilon(System.Single.NegativeInfinity, System.Single.PositiveInfinity);
             Assert.NotApproximatelyEqualEpsilon(System.Single.PositiveInfinity, System.Single.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(System.Single.NegativeInfinity, -System.Single.MaxValue);
@@ -163,18 +163,18 @@ module MathHelper =
             Assert.NotApproximatelyEqualEpsilon(-1.0f, 1.000000001f);
             Assert.NotApproximatelyEqualEpsilon(-1.000000001f, 1.0f);
             Assert.NotApproximatelyEqualEpsilon(1.0f, -1.000000001f);
-            Assert.ApproximatelyEquivalentEpsilon(10.0f * System.Single.Epsilon, 10.0f * -System.Single.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(10.0f * System.Single.Epsilon, 10.0f * -System.Single.Epsilon);
             Assert.NotApproximatelyEqualEpsilon(10000.0f * System.Single.Epsilon, 10000.0f * -System.Single.Epsilon);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for values very close to 0``() =
-            Assert.ApproximatelyEquivalentEpsilon(System.Single.Epsilon, System.Single.Epsilon);
-            Assert.ApproximatelyEquivalentEpsilon(System.Single.Epsilon, -System.Single.Epsilon);
-            Assert.ApproximatelyEquivalentEpsilon(-System.Single.Epsilon, System.Single.Epsilon);
-            Assert.ApproximatelyEquivalentEpsilon(System.Single.Epsilon, 0.0f);
-            Assert.ApproximatelyEquivalentEpsilon(0.0f, System.Single.Epsilon);
-            Assert.ApproximatelyEquivalentEpsilon(-System.Single.Epsilon, 0.0f);
-            Assert.ApproximatelyEquivalentEpsilon(0.0f, -System.Single.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(System.Single.Epsilon, System.Single.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(System.Single.Epsilon, -System.Single.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(-System.Single.Epsilon, System.Single.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(System.Single.Epsilon, 0.0f);
+            Assert.ApproximatelyEqualEpsilon(0.0f, System.Single.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(-System.Single.Epsilon, 0.0f);
+            Assert.ApproximatelyEqualEpsilon(0.0f, -System.Single.Epsilon);
 
             Assert.NotApproximatelyEqualEpsilon(0.000000001f, -System.Single.Epsilon);
             Assert.NotApproximatelyEqualEpsilon(0.000000001f, System.Single.Epsilon);
@@ -186,69 +186,69 @@ module MathHelper =
         //
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for large positive values``() =
-            Assert.ApproximatelyEquivalentEpsilon(1000000.0, 1000001.0);
-            Assert.ApproximatelyEquivalentEpsilon(1000001.0, 1000000.0);
+            Assert.ApproximatelyEqualEpsilon(1000000.0, 1000001.0);
+            Assert.ApproximatelyEqualEpsilon(1000001.0, 1000000.0);
             Assert.NotApproximatelyEqualEpsilon(10000.0, 10001.0);
             Assert.NotApproximatelyEqualEpsilon(10001.0, 10000.0);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for large negative values``() =
-            Assert.ApproximatelyEquivalentEpsilon(-1000000.0, -1000001.0);
-            Assert.ApproximatelyEquivalentEpsilon(-1000001.0, -1000000.0);
+            Assert.ApproximatelyEqualEpsilon(-1000000.0, -1000001.0);
+            Assert.ApproximatelyEqualEpsilon(-1000001.0, -1000000.0);
             Assert.NotApproximatelyEqualEpsilon(-10000.0, -10001.0);
             Assert.NotApproximatelyEqualEpsilon(-10001.0, -10000.0);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for positive values around 1``() =
-            Assert.ApproximatelyEquivalentEpsilon(1.0000001, 1.0000002);
-            Assert.ApproximatelyEquivalentEpsilon(1.0000002, 1.0000001);
+            Assert.ApproximatelyEqualEpsilon(1.0000001, 1.0000002);
+            Assert.ApproximatelyEqualEpsilon(1.0000002, 1.0000001);
             Assert.NotApproximatelyEqualEpsilon(1.0002, 1.0001);
             Assert.NotApproximatelyEqualEpsilon(1.0001, 1.0002);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for negative values around -1``() =
-            Assert.ApproximatelyEquivalentEpsilon(-1.000001, -1.000002);
-            Assert.ApproximatelyEquivalentEpsilon(-1.000002, -1.000001);
+            Assert.ApproximatelyEqualEpsilon(-1.000001, -1.000002);
+            Assert.ApproximatelyEqualEpsilon(-1.000002, -1.000001);
             Assert.NotApproximatelyEqualEpsilon(-1.0001, -1.0002);
             Assert.NotApproximatelyEqualEpsilon(-1.0002, -1.0001);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for values between 1 and 0``() =
-            Assert.ApproximatelyEquivalentEpsilon(0.000000001000001, 0.000000001000002);
-            Assert.ApproximatelyEquivalentEpsilon(0.000000001000002, 0.000000001000001);
+            Assert.ApproximatelyEqualEpsilon(0.000000001000001, 0.000000001000002);
+            Assert.ApproximatelyEqualEpsilon(0.000000001000002, 0.000000001000001);
             Assert.NotApproximatelyEqualEpsilon(0.000000000001002, 0.000000000001001);
             Assert.NotApproximatelyEqualEpsilon(0.000000000001001, 0.000000000001002);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for values between -1 and 0``() =
-            Assert.ApproximatelyEquivalentEpsilon(-0.000000001000001, -0.000000001000002);
-            Assert.ApproximatelyEquivalentEpsilon(-0.000000001000002, -0.000000001000001);
+            Assert.ApproximatelyEqualEpsilon(-0.000000001000001, -0.000000001000002);
+            Assert.ApproximatelyEqualEpsilon(-0.000000001000002, -0.000000001000001);
             Assert.NotApproximatelyEqualEpsilon(-0.000000000001002, -0.000000000001001);
             Assert.NotApproximatelyEqualEpsilon(-0.000000000001001, -0.000000000001002);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for comparisons involving 0``() =
-            Assert.ApproximatelyEquivalentEpsilon(0.0, 0.0);
-            Assert.ApproximatelyEquivalentEpsilon(0.0, -0.0);
-            Assert.ApproximatelyEquivalentEpsilon(-0.0, -0.0);
+            Assert.ApproximatelyEqualEpsilon(0.0, 0.0);
+            Assert.ApproximatelyEqualEpsilon(0.0, -0.0);
+            Assert.ApproximatelyEqualEpsilon(-0.0, -0.0);
             Assert.NotApproximatelyEqualEpsilon(0.00000001, 0.0);
             Assert.NotApproximatelyEqualEpsilon(0.0, 0.00000001);
             Assert.NotApproximatelyEqualEpsilon(-0.00000001, 0.0);
             Assert.NotApproximatelyEqualEpsilon(0.0, -0.00000001);
 
-            Assert.ApproximatelyEquivalentEpsilon(0.0, 1e-310, 0.01);
-            Assert.ApproximatelyEquivalentEpsilon(1e-310, 0.0, 0.01);
+            Assert.ApproximatelyEqualEpsilon(0.0, 1e-310, 0.01);
+            Assert.ApproximatelyEqualEpsilon(1e-310, 0.0, 0.01);
             Assert.NotApproximatelyEqualEpsilon(1e-310, 0.0, 0.000001);
             Assert.NotApproximatelyEqualEpsilon(0.0, 1e-310, 0.000001);
 
-            Assert.ApproximatelyEquivalentEpsilon(0.0, -1e-310, 0.1);
-            Assert.ApproximatelyEquivalentEpsilon(-1e-310, 0.0, 0.1);
+            Assert.ApproximatelyEqualEpsilon(0.0, -1e-310, 0.1);
+            Assert.ApproximatelyEqualEpsilon(-1e-310, 0.0, 0.1);
             Assert.NotApproximatelyEqualEpsilon(-1e-310, 0.0, 0.00000001);
             Assert.NotApproximatelyEqualEpsilon(0.0, -1e-310, 0.00000001);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for extreme values with overflow potential``() =
-            Assert.ApproximatelyEquivalentEpsilon(System.Double.MaxValue, System.Double.MaxValue);
+            Assert.ApproximatelyEqualEpsilon(System.Double.MaxValue, System.Double.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(System.Double.MaxValue, -System.Double.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(-System.Double.MaxValue, System.Double.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(System.Double.MaxValue, System.Double.MaxValue / 2.0);
@@ -257,8 +257,8 @@ module MathHelper =
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for values involving infinities``() =
-            Assert.ApproximatelyEquivalentEpsilon(System.Double.PositiveInfinity, System.Double.PositiveInfinity);
-            Assert.ApproximatelyEquivalentEpsilon(System.Double.NegativeInfinity, System.Double.NegativeInfinity);
+            Assert.ApproximatelyEqualEpsilon(System.Double.PositiveInfinity, System.Double.PositiveInfinity);
+            Assert.ApproximatelyEqualEpsilon(System.Double.NegativeInfinity, System.Double.NegativeInfinity);
             Assert.NotApproximatelyEqualEpsilon(System.Double.NegativeInfinity, System.Double.PositiveInfinity);
             Assert.NotApproximatelyEqualEpsilon(System.Double.PositiveInfinity, System.Double.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(System.Double.NegativeInfinity, -System.Double.MaxValue);
@@ -289,18 +289,18 @@ module MathHelper =
             Assert.NotApproximatelyEqualEpsilon(-1.0, 1.000000001);
             Assert.NotApproximatelyEqualEpsilon(-1.000000001, 1.0);
             Assert.NotApproximatelyEqualEpsilon(1.0, -1.000000001);
-            Assert.ApproximatelyEquivalentEpsilon(10.0 * System.Double.Epsilon, 10.0 * -System.Double.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(10.0 * System.Double.Epsilon, 10.0 * -System.Double.Epsilon);
             Assert.NotApproximatelyEqualEpsilon(100000000000.0 * System.Double.Epsilon, 100000000000.0 * -System.Double.Epsilon);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for values very close to 0``() =
-            Assert.ApproximatelyEquivalentEpsilon(System.Double.Epsilon, System.Double.Epsilon);
-            Assert.ApproximatelyEquivalentEpsilon(System.Double.Epsilon, -System.Double.Epsilon);
-            Assert.ApproximatelyEquivalentEpsilon(-System.Double.Epsilon, System.Double.Epsilon);
-            Assert.ApproximatelyEquivalentEpsilon(System.Double.Epsilon, 0.0);
-            Assert.ApproximatelyEquivalentEpsilon(0.0, System.Double.Epsilon);
-            Assert.ApproximatelyEquivalentEpsilon(-System.Double.Epsilon, 0.0);
-            Assert.ApproximatelyEquivalentEpsilon(0.0, -System.Double.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(System.Double.Epsilon, System.Double.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(System.Double.Epsilon, -System.Double.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(-System.Double.Epsilon, System.Double.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(System.Double.Epsilon, 0.0);
+            Assert.ApproximatelyEqualEpsilon(0.0, System.Double.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(-System.Double.Epsilon, 0.0);
+            Assert.ApproximatelyEqualEpsilon(0.0, -System.Double.Epsilon);
 
             Assert.NotApproximatelyEqualEpsilon(0.000000001, -System.Double.Epsilon);
             Assert.NotApproximatelyEqualEpsilon(0.000000001, System.Double.Epsilon);

--- a/tests/OpenTK.Tests/MathHelperTests.fs
+++ b/tests/OpenTK.Tests/MathHelperTests.fs
@@ -306,3 +306,47 @@ module MathHelper =
             Assert.NotApproximatelyEqualEpsilon(0.000000001, System.Double.Epsilon);
             Assert.NotApproximatelyEqualEpsilon(System.Double.Epsilon, 0.000000001);
             Assert.NotApproximatelyEqualEpsilon(-System.Double.Epsilon, 0.000000001);
+
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    module ``ApproximatelyEquivalent (tolerance diff)`` =
+        [<Fact>]
+        let ``ApproximatelyEquivalent correctly approximates equivalence where the difference falls below the tolerance``() =
+            let a = 0.0001f
+            let b = 0.00019f
+            Assert.NotEqual(a,b)
+            Assert.True(MathHelper.ApproximatelyEquivalent(a, b, 0.0001f))
+
+        [<Fact>]
+        let ``ApproximatelyEquivalent correctly approximates inequivalence where the difference is the tolerance``() =
+            let a = 0.0001f
+            let b = 0.0002f
+            Assert.NotEqual(a,b)
+            Assert.False(MathHelper.ApproximatelyEquivalent(a, b, 0.0001f))
+
+        [<Fact>]
+        let ``ApproximatelyEquivalent correctly approximates inequivalence where the difference exceeds the tolerance``() =
+            let a = 0.0001f
+            let b = 0.00021f
+            Assert.NotEqual(a,b)
+            Assert.False(MathHelper.ApproximatelyEquivalent(a, b, 0.0001f))
+
+        [<Fact>]
+        let ``ApproximatelyEquivalent reports very different values as non-equal even with a high tolerance``() =
+            let a = 2.0f
+            let b = 1.0f
+            Assert.NotEqual(a,b)
+            Assert.False(MathHelper.ApproximatelyEquivalent(a, b, 1.0f))
+
+        [<Fact>]
+        let ``ApproximatelyEquivalent works with single zero value``() =
+            let a = 1.0f
+            let b = 0.0f
+            Assert.NotEqual(a,b)
+            Assert.False(MathHelper.ApproximatelyEquivalent(a, b, 0.0001f))
+
+        [<Fact>]
+        let ``ApproximatelyEquivalent works with both zero values``() =
+            let a = 0.0f
+            let b = 0.0f
+            Assert.Equal(a,b)
+            Assert.True(MathHelper.ApproximatelyEquivalent(a, b, 0.0001f))

--- a/tests/OpenTK.Tests/MathHelperTests.fs
+++ b/tests/OpenTK.Tests/MathHelperTests.fs
@@ -7,7 +7,7 @@ open System
 open OpenTK
 
 module MathHelper =
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``ApproximatelyEqual (delta)`` =
         /// This test ensures that approximately equal can never get it 'wrong' about the values.
         [<Property>]
@@ -55,74 +55,74 @@ module MathHelper =
             Assert.Equal(a,b)
             Assert.True(MathHelper.ApproximatelyEqual(a,b,0))
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``ApproximatelyEqual (single-precision epsilon)`` =
         //
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for large positive values``() =
-            Assert.ApproximatelyEqualEpsilon(1000000.0f, 1000001.0f);
-            Assert.ApproximatelyEqualEpsilon(1000001.0f, 1000000.0f);
+            Assert.ApproximatelyEquivalentEpsilon(1000000.0f, 1000001.0f);
+            Assert.ApproximatelyEquivalentEpsilon(1000001.0f, 1000000.0f);
             Assert.NotApproximatelyEqualEpsilon(10000.0f, 10001.0f);
             Assert.NotApproximatelyEqualEpsilon(10001.0f, 10000.0f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for large negative values``() =
-            Assert.ApproximatelyEqualEpsilon(-1000000.0f, -1000001.0f);
-            Assert.ApproximatelyEqualEpsilon(-1000001.0f, -1000000.0f);
+            Assert.ApproximatelyEquivalentEpsilon(-1000000.0f, -1000001.0f);
+            Assert.ApproximatelyEquivalentEpsilon(-1000001.0f, -1000000.0f);
             Assert.NotApproximatelyEqualEpsilon(-10000.0f, -10001.0f);
             Assert.NotApproximatelyEqualEpsilon(-10001.0f, -10000.0f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for positive values around 1``() =
-            Assert.ApproximatelyEqualEpsilon(1.0000001f, 1.0000002f);
-            Assert.ApproximatelyEqualEpsilon(1.0000002f, 1.0000001f);
+            Assert.ApproximatelyEquivalentEpsilon(1.0000001f, 1.0000002f);
+            Assert.ApproximatelyEquivalentEpsilon(1.0000002f, 1.0000001f);
             Assert.NotApproximatelyEqualEpsilon(1.0002f, 1.0001f);
             Assert.NotApproximatelyEqualEpsilon(1.0001f, 1.0002f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for negative values around -1``() =
-            Assert.ApproximatelyEqualEpsilon(-1.000001f, -1.000002f);
-            Assert.ApproximatelyEqualEpsilon(-1.000002f, -1.000001f);
+            Assert.ApproximatelyEquivalentEpsilon(-1.000001f, -1.000002f);
+            Assert.ApproximatelyEquivalentEpsilon(-1.000002f, -1.000001f);
             Assert.NotApproximatelyEqualEpsilon(-1.0001f, -1.0002f);
             Assert.NotApproximatelyEqualEpsilon(-1.0002f, -1.0001f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for values between 1 and 0``() =
-            Assert.ApproximatelyEqualEpsilon(0.000000001000001f, 0.000000001000002f);
-            Assert.ApproximatelyEqualEpsilon(0.000000001000002f, 0.000000001000001f);
+            Assert.ApproximatelyEquivalentEpsilon(0.000000001000001f, 0.000000001000002f);
+            Assert.ApproximatelyEquivalentEpsilon(0.000000001000002f, 0.000000001000001f);
             Assert.NotApproximatelyEqualEpsilon(0.000000000001002f, 0.000000000001001f);
             Assert.NotApproximatelyEqualEpsilon(0.000000000001001f, 0.000000000001002f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for values between -1 and 0``() =
-            Assert.ApproximatelyEqualEpsilon(-0.000000001000001f, -0.000000001000002f);
-            Assert.ApproximatelyEqualEpsilon(-0.000000001000002f, -0.000000001000001f);
+            Assert.ApproximatelyEquivalentEpsilon(-0.000000001000001f, -0.000000001000002f);
+            Assert.ApproximatelyEquivalentEpsilon(-0.000000001000002f, -0.000000001000001f);
             Assert.NotApproximatelyEqualEpsilon(-0.000000000001002f, -0.000000000001001f);
             Assert.NotApproximatelyEqualEpsilon(-0.000000000001001f, -0.000000000001002f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for comparisons involving 0``() =
-            Assert.ApproximatelyEqualEpsilon(0.0f, 0.0f);
-            Assert.ApproximatelyEqualEpsilon(0.0f, -0.0f);
-            Assert.ApproximatelyEqualEpsilon(-0.0f, -0.0f);
+            Assert.ApproximatelyEquivalentEpsilon(0.0f, 0.0f);
+            Assert.ApproximatelyEquivalentEpsilon(0.0f, -0.0f);
+            Assert.ApproximatelyEquivalentEpsilon(-0.0f, -0.0f);
             Assert.NotApproximatelyEqualEpsilon(0.00000001f, 0.0f);
             Assert.NotApproximatelyEqualEpsilon(0.0f, 0.00000001f);
             Assert.NotApproximatelyEqualEpsilon(-0.00000001f, 0.0f);
             Assert.NotApproximatelyEqualEpsilon(0.0f, -0.00000001f);
 
-            Assert.ApproximatelyEqualEpsilon(0.0f, 1e-40f, 0.01f);
-            Assert.ApproximatelyEqualEpsilon(1e-40f, 0.0f, 0.01f);
+            Assert.ApproximatelyEquivalentEpsilon(0.0f, 1e-40f, 0.01f);
+            Assert.ApproximatelyEquivalentEpsilon(1e-40f, 0.0f, 0.01f);
             Assert.NotApproximatelyEqualEpsilon(1e-40f, 0.0f, 0.000001f);
             Assert.NotApproximatelyEqualEpsilon(0.0f, 1e-40f, 0.000001f);
 
-            Assert.ApproximatelyEqualEpsilon(0.0f, -1e-40f, 0.1f);
-            Assert.ApproximatelyEqualEpsilon(-1e-40f, 0.0f, 0.1f);
+            Assert.ApproximatelyEquivalentEpsilon(0.0f, -1e-40f, 0.1f);
+            Assert.ApproximatelyEquivalentEpsilon(-1e-40f, 0.0f, 0.1f);
             Assert.NotApproximatelyEqualEpsilon(-1e-40f, 0.0f, 0.00000001f);
             Assert.NotApproximatelyEqualEpsilon(0.0f, -1e-40f, 0.00000001f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for extreme values with overflow potential``() =
-            Assert.ApproximatelyEqualEpsilon(System.Single.MaxValue, System.Single.MaxValue);
+            Assert.ApproximatelyEquivalentEpsilon(System.Single.MaxValue, System.Single.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(System.Single.MaxValue, -System.Single.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(-System.Single.MaxValue, System.Single.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(System.Single.MaxValue, System.Single.MaxValue / 2.0f);
@@ -131,8 +131,8 @@ module MathHelper =
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for values involving infinities``() =
-            Assert.ApproximatelyEqualEpsilon(System.Single.PositiveInfinity, System.Single.PositiveInfinity);
-            Assert.ApproximatelyEqualEpsilon(System.Single.NegativeInfinity, System.Single.NegativeInfinity);
+            Assert.ApproximatelyEquivalentEpsilon(System.Single.PositiveInfinity, System.Single.PositiveInfinity);
+            Assert.ApproximatelyEquivalentEpsilon(System.Single.NegativeInfinity, System.Single.NegativeInfinity);
             Assert.NotApproximatelyEqualEpsilon(System.Single.NegativeInfinity, System.Single.PositiveInfinity);
             Assert.NotApproximatelyEqualEpsilon(System.Single.PositiveInfinity, System.Single.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(System.Single.NegativeInfinity, -System.Single.MaxValue);
@@ -163,92 +163,92 @@ module MathHelper =
             Assert.NotApproximatelyEqualEpsilon(-1.0f, 1.000000001f);
             Assert.NotApproximatelyEqualEpsilon(-1.000000001f, 1.0f);
             Assert.NotApproximatelyEqualEpsilon(1.0f, -1.000000001f);
-            Assert.ApproximatelyEqualEpsilon(10.0f * System.Single.Epsilon, 10.0f * -System.Single.Epsilon);
+            Assert.ApproximatelyEquivalentEpsilon(10.0f * System.Single.Epsilon, 10.0f * -System.Single.Epsilon);
             Assert.NotApproximatelyEqualEpsilon(10000.0f * System.Single.Epsilon, 10000.0f * -System.Single.Epsilon);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for values very close to 0``() =
-            Assert.ApproximatelyEqualEpsilon(System.Single.Epsilon, System.Single.Epsilon);
-            Assert.ApproximatelyEqualEpsilon(System.Single.Epsilon, -System.Single.Epsilon);
-            Assert.ApproximatelyEqualEpsilon(-System.Single.Epsilon, System.Single.Epsilon);
-            Assert.ApproximatelyEqualEpsilon(System.Single.Epsilon, 0.0f);
-            Assert.ApproximatelyEqualEpsilon(0.0f, System.Single.Epsilon);
-            Assert.ApproximatelyEqualEpsilon(-System.Single.Epsilon, 0.0f);
-            Assert.ApproximatelyEqualEpsilon(0.0f, -System.Single.Epsilon);
+            Assert.ApproximatelyEquivalentEpsilon(System.Single.Epsilon, System.Single.Epsilon);
+            Assert.ApproximatelyEquivalentEpsilon(System.Single.Epsilon, -System.Single.Epsilon);
+            Assert.ApproximatelyEquivalentEpsilon(-System.Single.Epsilon, System.Single.Epsilon);
+            Assert.ApproximatelyEquivalentEpsilon(System.Single.Epsilon, 0.0f);
+            Assert.ApproximatelyEquivalentEpsilon(0.0f, System.Single.Epsilon);
+            Assert.ApproximatelyEquivalentEpsilon(-System.Single.Epsilon, 0.0f);
+            Assert.ApproximatelyEquivalentEpsilon(0.0f, -System.Single.Epsilon);
 
             Assert.NotApproximatelyEqualEpsilon(0.000000001f, -System.Single.Epsilon);
             Assert.NotApproximatelyEqualEpsilon(0.000000001f, System.Single.Epsilon);
             Assert.NotApproximatelyEqualEpsilon(System.Single.Epsilon, 0.000000001f);
             Assert.NotApproximatelyEqualEpsilon(-System.Single.Epsilon, 0.000000001f);
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``ApproximatelyEqual (double-precision epsilon)`` =
         //
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for large positive values``() =
-            Assert.ApproximatelyEqualEpsilon(1000000.0, 1000001.0);
-            Assert.ApproximatelyEqualEpsilon(1000001.0, 1000000.0);
+            Assert.ApproximatelyEquivalentEpsilon(1000000.0, 1000001.0);
+            Assert.ApproximatelyEquivalentEpsilon(1000001.0, 1000000.0);
             Assert.NotApproximatelyEqualEpsilon(10000.0, 10001.0);
             Assert.NotApproximatelyEqualEpsilon(10001.0, 10000.0);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for large negative values``() =
-            Assert.ApproximatelyEqualEpsilon(-1000000.0, -1000001.0);
-            Assert.ApproximatelyEqualEpsilon(-1000001.0, -1000000.0);
+            Assert.ApproximatelyEquivalentEpsilon(-1000000.0, -1000001.0);
+            Assert.ApproximatelyEquivalentEpsilon(-1000001.0, -1000000.0);
             Assert.NotApproximatelyEqualEpsilon(-10000.0, -10001.0);
             Assert.NotApproximatelyEqualEpsilon(-10001.0, -10000.0);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for positive values around 1``() =
-            Assert.ApproximatelyEqualEpsilon(1.0000001, 1.0000002);
-            Assert.ApproximatelyEqualEpsilon(1.0000002, 1.0000001);
+            Assert.ApproximatelyEquivalentEpsilon(1.0000001, 1.0000002);
+            Assert.ApproximatelyEquivalentEpsilon(1.0000002, 1.0000001);
             Assert.NotApproximatelyEqualEpsilon(1.0002, 1.0001);
             Assert.NotApproximatelyEqualEpsilon(1.0001, 1.0002);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for negative values around -1``() =
-            Assert.ApproximatelyEqualEpsilon(-1.000001, -1.000002);
-            Assert.ApproximatelyEqualEpsilon(-1.000002, -1.000001);
+            Assert.ApproximatelyEquivalentEpsilon(-1.000001, -1.000002);
+            Assert.ApproximatelyEquivalentEpsilon(-1.000002, -1.000001);
             Assert.NotApproximatelyEqualEpsilon(-1.0001, -1.0002);
             Assert.NotApproximatelyEqualEpsilon(-1.0002, -1.0001);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for values between 1 and 0``() =
-            Assert.ApproximatelyEqualEpsilon(0.000000001000001, 0.000000001000002);
-            Assert.ApproximatelyEqualEpsilon(0.000000001000002, 0.000000001000001);
+            Assert.ApproximatelyEquivalentEpsilon(0.000000001000001, 0.000000001000002);
+            Assert.ApproximatelyEquivalentEpsilon(0.000000001000002, 0.000000001000001);
             Assert.NotApproximatelyEqualEpsilon(0.000000000001002, 0.000000000001001);
             Assert.NotApproximatelyEqualEpsilon(0.000000000001001, 0.000000000001002);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for values between -1 and 0``() =
-            Assert.ApproximatelyEqualEpsilon(-0.000000001000001, -0.000000001000002);
-            Assert.ApproximatelyEqualEpsilon(-0.000000001000002, -0.000000001000001);
+            Assert.ApproximatelyEquivalentEpsilon(-0.000000001000001, -0.000000001000002);
+            Assert.ApproximatelyEquivalentEpsilon(-0.000000001000002, -0.000000001000001);
             Assert.NotApproximatelyEqualEpsilon(-0.000000000001002, -0.000000000001001);
             Assert.NotApproximatelyEqualEpsilon(-0.000000000001001, -0.000000000001002);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for comparisons involving 0``() =
-            Assert.ApproximatelyEqualEpsilon(0.0, 0.0);
-            Assert.ApproximatelyEqualEpsilon(0.0, -0.0);
-            Assert.ApproximatelyEqualEpsilon(-0.0, -0.0);
+            Assert.ApproximatelyEquivalentEpsilon(0.0, 0.0);
+            Assert.ApproximatelyEquivalentEpsilon(0.0, -0.0);
+            Assert.ApproximatelyEquivalentEpsilon(-0.0, -0.0);
             Assert.NotApproximatelyEqualEpsilon(0.00000001, 0.0);
             Assert.NotApproximatelyEqualEpsilon(0.0, 0.00000001);
             Assert.NotApproximatelyEqualEpsilon(-0.00000001, 0.0);
             Assert.NotApproximatelyEqualEpsilon(0.0, -0.00000001);
 
-            Assert.ApproximatelyEqualEpsilon(0.0, 1e-310, 0.01);
-            Assert.ApproximatelyEqualEpsilon(1e-310, 0.0, 0.01);
+            Assert.ApproximatelyEquivalentEpsilon(0.0, 1e-310, 0.01);
+            Assert.ApproximatelyEquivalentEpsilon(1e-310, 0.0, 0.01);
             Assert.NotApproximatelyEqualEpsilon(1e-310, 0.0, 0.000001);
             Assert.NotApproximatelyEqualEpsilon(0.0, 1e-310, 0.000001);
 
-            Assert.ApproximatelyEqualEpsilon(0.0, -1e-310, 0.1);
-            Assert.ApproximatelyEqualEpsilon(-1e-310, 0.0, 0.1);
+            Assert.ApproximatelyEquivalentEpsilon(0.0, -1e-310, 0.1);
+            Assert.ApproximatelyEquivalentEpsilon(-1e-310, 0.0, 0.1);
             Assert.NotApproximatelyEqualEpsilon(-1e-310, 0.0, 0.00000001);
             Assert.NotApproximatelyEqualEpsilon(0.0, -1e-310, 0.00000001);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for extreme values with overflow potential``() =
-            Assert.ApproximatelyEqualEpsilon(System.Double.MaxValue, System.Double.MaxValue);
+            Assert.ApproximatelyEquivalentEpsilon(System.Double.MaxValue, System.Double.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(System.Double.MaxValue, -System.Double.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(-System.Double.MaxValue, System.Double.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(System.Double.MaxValue, System.Double.MaxValue / 2.0);
@@ -257,8 +257,8 @@ module MathHelper =
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for values involving infinities``() =
-            Assert.ApproximatelyEqualEpsilon(System.Double.PositiveInfinity, System.Double.PositiveInfinity);
-            Assert.ApproximatelyEqualEpsilon(System.Double.NegativeInfinity, System.Double.NegativeInfinity);
+            Assert.ApproximatelyEquivalentEpsilon(System.Double.PositiveInfinity, System.Double.PositiveInfinity);
+            Assert.ApproximatelyEquivalentEpsilon(System.Double.NegativeInfinity, System.Double.NegativeInfinity);
             Assert.NotApproximatelyEqualEpsilon(System.Double.NegativeInfinity, System.Double.PositiveInfinity);
             Assert.NotApproximatelyEqualEpsilon(System.Double.PositiveInfinity, System.Double.MaxValue);
             Assert.NotApproximatelyEqualEpsilon(System.Double.NegativeInfinity, -System.Double.MaxValue);
@@ -289,25 +289,25 @@ module MathHelper =
             Assert.NotApproximatelyEqualEpsilon(-1.0, 1.000000001);
             Assert.NotApproximatelyEqualEpsilon(-1.000000001, 1.0);
             Assert.NotApproximatelyEqualEpsilon(1.0, -1.000000001);
-            Assert.ApproximatelyEqualEpsilon(10.0 * System.Double.Epsilon, 10.0 * -System.Double.Epsilon);
+            Assert.ApproximatelyEquivalentEpsilon(10.0 * System.Double.Epsilon, 10.0 * -System.Double.Epsilon);
             Assert.NotApproximatelyEqualEpsilon(100000000000.0 * System.Double.Epsilon, 100000000000.0 * -System.Double.Epsilon);
 
         [<Fact>]
         let ``ApproximatelyEqual (double precision) is correct for values very close to 0``() =
-            Assert.ApproximatelyEqualEpsilon(System.Double.Epsilon, System.Double.Epsilon);
-            Assert.ApproximatelyEqualEpsilon(System.Double.Epsilon, -System.Double.Epsilon);
-            Assert.ApproximatelyEqualEpsilon(-System.Double.Epsilon, System.Double.Epsilon);
-            Assert.ApproximatelyEqualEpsilon(System.Double.Epsilon, 0.0);
-            Assert.ApproximatelyEqualEpsilon(0.0, System.Double.Epsilon);
-            Assert.ApproximatelyEqualEpsilon(-System.Double.Epsilon, 0.0);
-            Assert.ApproximatelyEqualEpsilon(0.0, -System.Double.Epsilon);
+            Assert.ApproximatelyEquivalentEpsilon(System.Double.Epsilon, System.Double.Epsilon);
+            Assert.ApproximatelyEquivalentEpsilon(System.Double.Epsilon, -System.Double.Epsilon);
+            Assert.ApproximatelyEquivalentEpsilon(-System.Double.Epsilon, System.Double.Epsilon);
+            Assert.ApproximatelyEquivalentEpsilon(System.Double.Epsilon, 0.0);
+            Assert.ApproximatelyEquivalentEpsilon(0.0, System.Double.Epsilon);
+            Assert.ApproximatelyEquivalentEpsilon(-System.Double.Epsilon, 0.0);
+            Assert.ApproximatelyEquivalentEpsilon(0.0, -System.Double.Epsilon);
 
             Assert.NotApproximatelyEqualEpsilon(0.000000001, -System.Double.Epsilon);
             Assert.NotApproximatelyEqualEpsilon(0.000000001, System.Double.Epsilon);
             Assert.NotApproximatelyEqualEpsilon(System.Double.Epsilon, 0.000000001);
             Assert.NotApproximatelyEqualEpsilon(-System.Double.Epsilon, 0.000000001);
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``ApproximatelyEquivalent (tolerance diff)`` =
         [<Fact>]
         let ``ApproximatelyEquivalent correctly approximates equivalence where the difference falls below the tolerance``() =
@@ -317,11 +317,11 @@ module MathHelper =
             Assert.True(MathHelper.ApproximatelyEquivalent(a, b, 0.0001f))
 
         [<Fact>]
-        let ``ApproximatelyEquivalent correctly approximates inequivalence where the difference is the tolerance``() =
+        let ``ApproximatelyEquivalent correctly approximates equivalence where the difference is the tolerance``() =
             let a = 0.0001f
             let b = 0.0002f
             Assert.NotEqual(a,b)
-            Assert.False(MathHelper.ApproximatelyEquivalent(a, b, 0.0001f))
+            Assert.True(MathHelper.ApproximatelyEquivalent(a, b, 0.0001f))
 
         [<Fact>]
         let ``ApproximatelyEquivalent correctly approximates inequivalence where the difference exceeds the tolerance``() =
@@ -332,7 +332,7 @@ module MathHelper =
 
         [<Fact>]
         let ``ApproximatelyEquivalent reports very different values as non-equal even with a high tolerance``() =
-            let a = 2.0f
+            let a = 3.0f
             let b = 1.0f
             Assert.NotEqual(a,b)
             Assert.False(MathHelper.ApproximatelyEquivalent(a, b, 1.0f))

--- a/tests/OpenTK.Tests/MathHelperTests.fs
+++ b/tests/OpenTK.Tests/MathHelperTests.fs
@@ -6,50 +6,303 @@ open FsCheck.Xunit
 open System
 open OpenTK
 
-[<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
 module MathHelper =
-    /// This test ensures that approximately equal can never get it 'wrong' about the values.
-    [<Property>]
-    let ``ApproximatelyEqual is never incorrect`` (a : float32,b : float32,bits : int32) =
-        let clamped = max 0 (min bits 24)
-        let areApproxEqual = MathHelper.ApproximatelyEqual(a,b,clamped)
-        let areExactlyEqual = a = b
-        let isWrong = areExactlyEqual && not areApproxEqual
-        Assert.False(isWrong)
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    module ``ApproximatelyEqual (delta)`` =
+        /// This test ensures that approximately equal can never get it 'wrong' about the values.
+        [<Property>]
+        let ``ApproximatelyEqual is never incorrect`` (a : float32,b : float32,bits : int32) =
+            let clamped = max 0 (min bits 24)
+            let areApproxEqual = MathHelper.ApproximatelyEqual(a,b,clamped)
+            let areExactlyEqual = a = b
+            let isWrong = areExactlyEqual && not areApproxEqual
+            Assert.False(isWrong)
 
-    [<Property>]
-    let ``ApproximatelyEqual can return true if some values are not exactly equal`` (a : float32,b : float32,bits : int32) =
-        let clamped = max 0 (min bits 24)
-        let areApproxEqual = MathHelper.ApproximatelyEqual(a,b,clamped)
-        let areExactlyEqual = a = b
-        let isWrong = areExactlyEqual && not areApproxEqual
-        let p = new PropertyAttribute()
-        Assert.False(isWrong)
+        [<Property>]
+        let ``ApproximatelyEqual can return true if some values are not exactly equal`` (a : float32,b : float32,bits : int32) =
+            let clamped = max 0 (min bits 24)
+            let areApproxEqual = MathHelper.ApproximatelyEqual(a,b,clamped)
+            let areExactlyEqual = a = b
+            let isWrong = areExactlyEqual && not areApproxEqual
+            let p = new PropertyAttribute()
+            Assert.False(isWrong)
 
-    [<Fact>]
-    let ``ApproximatelyEqual correctly approximates equality``() =
-        let a = 0.000000001f
-        let b = 0.0000000010000001f
-        Assert.NotEqual(a,b)
-        [ 1..24 ] |> List.iter (fun i -> Assert.True(MathHelper.ApproximatelyEqual(a,b,i)))
+        [<Fact>]
+        let ``ApproximatelyEqual correctly approximates equality``() =
+            let a = 0.000000001f
+            let b = 0.0000000010000001f
+            Assert.NotEqual(a,b)
+            [ 1..24 ] |> List.iter (fun i -> Assert.True(MathHelper.ApproximatelyEqual(a,b,i)))
 
-    [<Fact>]
-    let ``ApproximatelyEqual reports very different values as non-equal even with high bit count``() =
-        let a = 2.0f
-        let b = 1.0f
-        Assert.NotEqual(a,b)
-        Assert.False(MathHelper.ApproximatelyEqual(a,b,10))
+        [<Fact>]
+        let ``ApproximatelyEqual reports very different values as non-equal even with high bit count``() =
+            let a = 2.0f
+            let b = 1.0f
+            Assert.NotEqual(a,b)
+            Assert.False(MathHelper.ApproximatelyEqual(a,b,10))
 
-    [<Fact>]
-    let ``ApproximatelyEqual works with single zero value``() =
-        let a = 1.0f
-        let b = 0.0f
-        Assert.NotEqual(a,b)
-        Assert.False(MathHelper.ApproximatelyEqual(a,b,0))
+        [<Fact>]
+        let ``ApproximatelyEqual works with single zero value``() =
+            let a = 1.0f
+            let b = 0.0f
+            Assert.NotEqual(a,b)
+            Assert.False(MathHelper.ApproximatelyEqual(a,b,0))
 
-    [<Fact>]
-    let ``ApproximatelyEqual works with both zero values``() =
-        let a = 0.0f
-        let b = 0.0f
-        Assert.Equal(a,b)
-        Assert.True(MathHelper.ApproximatelyEqual(a,b,0))
+        [<Fact>]
+        let ``ApproximatelyEqual works with both zero values``() =
+            let a = 0.0f
+            let b = 0.0f
+            Assert.Equal(a,b)
+            Assert.True(MathHelper.ApproximatelyEqual(a,b,0))
+
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    module ``ApproximatelyEqual (single-precision epsilon)`` =
+        //
+        [<Fact>]
+        let ``ApproximatelyEqual (single precision) is correct for large positive values``() =
+            Assert.ApproximatelyEqualEpsilon(1000000.0f, 1000001.0f);
+            Assert.ApproximatelyEqualEpsilon(1000001.0f, 1000000.0f);
+            Assert.NotApproximatelyEqualEpsilon(10000.0f, 10001.0f);
+            Assert.NotApproximatelyEqualEpsilon(10001.0f, 10000.0f);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (single precision) is correct for large negative values``() =
+            Assert.ApproximatelyEqualEpsilon(-1000000.0f, -1000001.0f);
+            Assert.ApproximatelyEqualEpsilon(-1000001.0f, -1000000.0f);
+            Assert.NotApproximatelyEqualEpsilon(-10000.0f, -10001.0f);
+            Assert.NotApproximatelyEqualEpsilon(-10001.0f, -10000.0f);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (single precision) is correct for positive values around 1``() =
+            Assert.ApproximatelyEqualEpsilon(1.0000001f, 1.0000002f);
+            Assert.ApproximatelyEqualEpsilon(1.0000002f, 1.0000001f);
+            Assert.NotApproximatelyEqualEpsilon(1.0002f, 1.0001f);
+            Assert.NotApproximatelyEqualEpsilon(1.0001f, 1.0002f);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (single precision) is correct for negative values around -1``() =
+            Assert.ApproximatelyEqualEpsilon(-1.000001f, -1.000002f);
+            Assert.ApproximatelyEqualEpsilon(-1.000002f, -1.000001f);
+            Assert.NotApproximatelyEqualEpsilon(-1.0001f, -1.0002f);
+            Assert.NotApproximatelyEqualEpsilon(-1.0002f, -1.0001f);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (single precision) is correct for values between 1 and 0``() =
+            Assert.ApproximatelyEqualEpsilon(0.000000001000001f, 0.000000001000002f);
+            Assert.ApproximatelyEqualEpsilon(0.000000001000002f, 0.000000001000001f);
+            Assert.NotApproximatelyEqualEpsilon(0.000000000001002f, 0.000000000001001f);
+            Assert.NotApproximatelyEqualEpsilon(0.000000000001001f, 0.000000000001002f);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (single precision) is correct for values between -1 and 0``() =
+            Assert.ApproximatelyEqualEpsilon(-0.000000001000001f, -0.000000001000002f);
+            Assert.ApproximatelyEqualEpsilon(-0.000000001000002f, -0.000000001000001f);
+            Assert.NotApproximatelyEqualEpsilon(-0.000000000001002f, -0.000000000001001f);
+            Assert.NotApproximatelyEqualEpsilon(-0.000000000001001f, -0.000000000001002f);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (single precision) is correct for comparisons involving 0``() =
+            Assert.ApproximatelyEqualEpsilon(0.0f, 0.0f);
+            Assert.ApproximatelyEqualEpsilon(0.0f, -0.0f);
+            Assert.ApproximatelyEqualEpsilon(-0.0f, -0.0f);
+            Assert.NotApproximatelyEqualEpsilon(0.00000001f, 0.0f);
+            Assert.NotApproximatelyEqualEpsilon(0.0f, 0.00000001f);
+            Assert.NotApproximatelyEqualEpsilon(-0.00000001f, 0.0f);
+            Assert.NotApproximatelyEqualEpsilon(0.0f, -0.00000001f);
+
+            Assert.ApproximatelyEqualEpsilon(0.0f, 1e-40f, 0.01f);
+            Assert.ApproximatelyEqualEpsilon(1e-40f, 0.0f, 0.01f);
+            Assert.NotApproximatelyEqualEpsilon(1e-40f, 0.0f, 0.000001f);
+            Assert.NotApproximatelyEqualEpsilon(0.0f, 1e-40f, 0.000001f);
+
+            Assert.ApproximatelyEqualEpsilon(0.0f, -1e-40f, 0.1f);
+            Assert.ApproximatelyEqualEpsilon(-1e-40f, 0.0f, 0.1f);
+            Assert.NotApproximatelyEqualEpsilon(-1e-40f, 0.0f, 0.00000001f);
+            Assert.NotApproximatelyEqualEpsilon(0.0f, -1e-40f, 0.00000001f);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (single precision) is correct for extreme values with overflow potential``() =
+            Assert.ApproximatelyEqualEpsilon(System.Single.MaxValue, System.Single.MaxValue);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.MaxValue, -System.Single.MaxValue);
+            Assert.NotApproximatelyEqualEpsilon(-System.Single.MaxValue, System.Single.MaxValue);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.MaxValue, System.Single.MaxValue / 2.0f);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.MaxValue, -System.Single.MaxValue / 2.0f);
+            Assert.NotApproximatelyEqualEpsilon(-System.Single.MaxValue, System.Single.MaxValue / 2.0f);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (single precision) is correct for values involving infinities``() =
+            Assert.ApproximatelyEqualEpsilon(System.Single.PositiveInfinity, System.Single.PositiveInfinity);
+            Assert.ApproximatelyEqualEpsilon(System.Single.NegativeInfinity, System.Single.NegativeInfinity);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.NegativeInfinity, System.Single.PositiveInfinity);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.PositiveInfinity, System.Single.MaxValue);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.NegativeInfinity, -System.Single.MaxValue);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (single precision) is correct for values involving NaN``() =
+            Assert.NotApproximatelyEqualEpsilon(System.Single.NaN, System.Single.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.NaN, 0.0f);
+            Assert.NotApproximatelyEqualEpsilon(-0.0f, System.Single.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.NaN, -0.0f);
+            Assert.NotApproximatelyEqualEpsilon(0.0f, System.Single.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.NaN, System.Single.PositiveInfinity);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.PositiveInfinity, System.Single.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.NaN, System.Single.NegativeInfinity);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.NegativeInfinity, System.Single.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.NaN, System.Single.MaxValue);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.MaxValue, System.Single.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.NaN, -System.Single.MaxValue);
+            Assert.NotApproximatelyEqualEpsilon(-System.Single.MaxValue, System.Single.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.NaN, System.Single.Epsilon);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.Epsilon, System.Single.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.NaN, -System.Single.Epsilon);
+            Assert.NotApproximatelyEqualEpsilon(-System.Single.Epsilon, System.Single.NaN);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (single precision) is correct for values on opposite sides of 0``() =
+            Assert.NotApproximatelyEqualEpsilon(1.000000001f, -1.0f);
+            Assert.NotApproximatelyEqualEpsilon(-1.0f, 1.000000001f);
+            Assert.NotApproximatelyEqualEpsilon(-1.000000001f, 1.0f);
+            Assert.NotApproximatelyEqualEpsilon(1.0f, -1.000000001f);
+            Assert.ApproximatelyEqualEpsilon(10.0f * System.Single.Epsilon, 10.0f * -System.Single.Epsilon);
+            Assert.NotApproximatelyEqualEpsilon(10000.0f * System.Single.Epsilon, 10000.0f * -System.Single.Epsilon);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (single precision) is correct for values very close to 0``() =
+            Assert.ApproximatelyEqualEpsilon(System.Single.Epsilon, System.Single.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(System.Single.Epsilon, -System.Single.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(-System.Single.Epsilon, System.Single.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(System.Single.Epsilon, 0.0f);
+            Assert.ApproximatelyEqualEpsilon(0.0f, System.Single.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(-System.Single.Epsilon, 0.0f);
+            Assert.ApproximatelyEqualEpsilon(0.0f, -System.Single.Epsilon);
+
+            Assert.NotApproximatelyEqualEpsilon(0.000000001f, -System.Single.Epsilon);
+            Assert.NotApproximatelyEqualEpsilon(0.000000001f, System.Single.Epsilon);
+            Assert.NotApproximatelyEqualEpsilon(System.Single.Epsilon, 0.000000001f);
+            Assert.NotApproximatelyEqualEpsilon(-System.Single.Epsilon, 0.000000001f);
+
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    module ``ApproximatelyEqual (double-precision epsilon)`` =
+        //
+        [<Fact>]
+        let ``ApproximatelyEqual (double precision) is correct for large positive values``() =
+            Assert.ApproximatelyEqualEpsilon(1000000.0, 1000001.0);
+            Assert.ApproximatelyEqualEpsilon(1000001.0, 1000000.0);
+            Assert.NotApproximatelyEqualEpsilon(10000.0, 10001.0);
+            Assert.NotApproximatelyEqualEpsilon(10001.0, 10000.0);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (double precision) is correct for large negative values``() =
+            Assert.ApproximatelyEqualEpsilon(-1000000.0, -1000001.0);
+            Assert.ApproximatelyEqualEpsilon(-1000001.0, -1000000.0);
+            Assert.NotApproximatelyEqualEpsilon(-10000.0, -10001.0);
+            Assert.NotApproximatelyEqualEpsilon(-10001.0, -10000.0);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (double precision) is correct for positive values around 1``() =
+            Assert.ApproximatelyEqualEpsilon(1.0000001, 1.0000002);
+            Assert.ApproximatelyEqualEpsilon(1.0000002, 1.0000001);
+            Assert.NotApproximatelyEqualEpsilon(1.0002, 1.0001);
+            Assert.NotApproximatelyEqualEpsilon(1.0001, 1.0002);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (double precision) is correct for negative values around -1``() =
+            Assert.ApproximatelyEqualEpsilon(-1.000001, -1.000002);
+            Assert.ApproximatelyEqualEpsilon(-1.000002, -1.000001);
+            Assert.NotApproximatelyEqualEpsilon(-1.0001, -1.0002);
+            Assert.NotApproximatelyEqualEpsilon(-1.0002, -1.0001);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (double precision) is correct for values between 1 and 0``() =
+            Assert.ApproximatelyEqualEpsilon(0.000000001000001, 0.000000001000002);
+            Assert.ApproximatelyEqualEpsilon(0.000000001000002, 0.000000001000001);
+            Assert.NotApproximatelyEqualEpsilon(0.000000000001002, 0.000000000001001);
+            Assert.NotApproximatelyEqualEpsilon(0.000000000001001, 0.000000000001002);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (double precision) is correct for values between -1 and 0``() =
+            Assert.ApproximatelyEqualEpsilon(-0.000000001000001, -0.000000001000002);
+            Assert.ApproximatelyEqualEpsilon(-0.000000001000002, -0.000000001000001);
+            Assert.NotApproximatelyEqualEpsilon(-0.000000000001002, -0.000000000001001);
+            Assert.NotApproximatelyEqualEpsilon(-0.000000000001001, -0.000000000001002);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (double precision) is correct for comparisons involving 0``() =
+            Assert.ApproximatelyEqualEpsilon(0.0, 0.0);
+            Assert.ApproximatelyEqualEpsilon(0.0, -0.0);
+            Assert.ApproximatelyEqualEpsilon(-0.0, -0.0);
+            Assert.NotApproximatelyEqualEpsilon(0.00000001, 0.0);
+            Assert.NotApproximatelyEqualEpsilon(0.0, 0.00000001);
+            Assert.NotApproximatelyEqualEpsilon(-0.00000001, 0.0);
+            Assert.NotApproximatelyEqualEpsilon(0.0, -0.00000001);
+
+            Assert.ApproximatelyEqualEpsilon(0.0, 1e-310, 0.01);
+            Assert.ApproximatelyEqualEpsilon(1e-310, 0.0, 0.01);
+            Assert.NotApproximatelyEqualEpsilon(1e-310, 0.0, 0.000001);
+            Assert.NotApproximatelyEqualEpsilon(0.0, 1e-310, 0.000001);
+
+            Assert.ApproximatelyEqualEpsilon(0.0, -1e-310, 0.1);
+            Assert.ApproximatelyEqualEpsilon(-1e-310, 0.0, 0.1);
+            Assert.NotApproximatelyEqualEpsilon(-1e-310, 0.0, 0.00000001);
+            Assert.NotApproximatelyEqualEpsilon(0.0, -1e-310, 0.00000001);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (double precision) is correct for extreme values with overflow potential``() =
+            Assert.ApproximatelyEqualEpsilon(System.Double.MaxValue, System.Double.MaxValue);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.MaxValue, -System.Double.MaxValue);
+            Assert.NotApproximatelyEqualEpsilon(-System.Double.MaxValue, System.Double.MaxValue);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.MaxValue, System.Double.MaxValue / 2.0);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.MaxValue, -System.Double.MaxValue / 2.0);
+            Assert.NotApproximatelyEqualEpsilon(-System.Double.MaxValue, System.Double.MaxValue / 2.0);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (double precision) is correct for values involving infinities``() =
+            Assert.ApproximatelyEqualEpsilon(System.Double.PositiveInfinity, System.Double.PositiveInfinity);
+            Assert.ApproximatelyEqualEpsilon(System.Double.NegativeInfinity, System.Double.NegativeInfinity);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.NegativeInfinity, System.Double.PositiveInfinity);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.PositiveInfinity, System.Double.MaxValue);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.NegativeInfinity, -System.Double.MaxValue);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (double precision) is correct for values involving NaN``() =
+            Assert.NotApproximatelyEqualEpsilon(System.Double.NaN, System.Double.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.NaN, 0.0);
+            Assert.NotApproximatelyEqualEpsilon(-0.0, System.Double.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.NaN, -0.0);
+            Assert.NotApproximatelyEqualEpsilon(0.0, System.Double.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.NaN, System.Double.PositiveInfinity);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.PositiveInfinity, System.Double.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.NaN, System.Double.NegativeInfinity);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.NegativeInfinity, System.Double.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.NaN, System.Double.MaxValue);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.MaxValue, System.Double.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.NaN, -System.Double.MaxValue);
+            Assert.NotApproximatelyEqualEpsilon(-System.Double.MaxValue, System.Double.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.NaN, System.Double.Epsilon);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.Epsilon, System.Double.NaN);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.NaN, -System.Double.Epsilon);
+            Assert.NotApproximatelyEqualEpsilon(-System.Double.Epsilon, System.Double.NaN);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (double precision) is correct for values on opposite sides of 0``() =
+            Assert.NotApproximatelyEqualEpsilon(1.000000001, -1.0);
+            Assert.NotApproximatelyEqualEpsilon(-1.0, 1.000000001);
+            Assert.NotApproximatelyEqualEpsilon(-1.000000001, 1.0);
+            Assert.NotApproximatelyEqualEpsilon(1.0, -1.000000001);
+            Assert.ApproximatelyEqualEpsilon(10.0 * System.Double.Epsilon, 10.0 * -System.Double.Epsilon);
+            Assert.NotApproximatelyEqualEpsilon(100000000000.0 * System.Double.Epsilon, 100000000000.0 * -System.Double.Epsilon);
+
+        [<Fact>]
+        let ``ApproximatelyEqual (double precision) is correct for values very close to 0``() =
+            Assert.ApproximatelyEqualEpsilon(System.Double.Epsilon, System.Double.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(System.Double.Epsilon, -System.Double.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(-System.Double.Epsilon, System.Double.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(System.Double.Epsilon, 0.0);
+            Assert.ApproximatelyEqualEpsilon(0.0, System.Double.Epsilon);
+            Assert.ApproximatelyEqualEpsilon(-System.Double.Epsilon, 0.0);
+            Assert.ApproximatelyEqualEpsilon(0.0, -System.Double.Epsilon);
+
+            Assert.NotApproximatelyEqualEpsilon(0.000000001, -System.Double.Epsilon);
+            Assert.NotApproximatelyEqualEpsilon(0.000000001, System.Double.Epsilon);
+            Assert.NotApproximatelyEqualEpsilon(System.Double.Epsilon, 0.000000001);
+            Assert.NotApproximatelyEqualEpsilon(-System.Double.Epsilon, 0.000000001);

--- a/tests/OpenTK.Tests/Matrix4Tests.fs
+++ b/tests/OpenTK.Tests/Matrix4Tests.fs
@@ -7,7 +7,7 @@ open System
 open OpenTK
 
 module Matrix4 =
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Constructors =
         //
         [<Property>]
@@ -88,7 +88,7 @@ module Matrix4 =
             Assert.Equal(o, A.M43)
             Assert.Equal(p, A.M44)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Equality =
         //
         [<Property>]
@@ -103,7 +103,7 @@ module Matrix4 =
         let ``A matrix is not equal to an object which is not a matrix`` (a : Matrix4, b : Vector3) =
             Assert.False(a.Equals(b))
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Multiplication =
         //
         [<Property>]
@@ -202,7 +202,7 @@ module Matrix4 =
             Assert.Equal(R4, AScaled.Row3)
 
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Addition =
         //
         [<Property>]
@@ -232,7 +232,7 @@ module Matrix4 =
             Assert.Equal(o + o, sum.M43)
             Assert.Equal(p + p, sum.M44)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Subtraction =
         //
         [<Property>]
@@ -262,7 +262,7 @@ module Matrix4 =
             Assert.Equal(o - o, sub.M43)
             Assert.Equal(p - p, sub.M44)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Indexing =
         //
         [<Property>]
@@ -338,7 +338,7 @@ module Matrix4 =
         let ``Indexed set operator throws exception for negative indices`` (b : Matrix4, x : float32) =
             let mutable a = b
 
-            
+
 
             (fun() -> a.[-1, 2] <- x) |> Assert.ThrowsIndexExn
             (fun() -> a.[1, -2] <- x) |> Assert.ThrowsIndexExn
@@ -363,7 +363,7 @@ module Matrix4 =
             (fun() -> a.[1, 6] |> ignore) |> Assert.ThrowsIndexExn
             (fun() -> a.[7, 12] |> ignore) |> Assert.ThrowsIndexExn
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Row and column properties`` =
         //
         [<Property>]

--- a/tests/OpenTK.Tests/Matrix4Tests.fs
+++ b/tests/OpenTK.Tests/Matrix4Tests.fs
@@ -7,7 +7,7 @@ open System
 open OpenTK
 
 module Matrix4 =
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Constructors =
         //
         [<Property>]
@@ -88,7 +88,7 @@ module Matrix4 =
             Assert.Equal(o, A.M43)
             Assert.Equal(p, A.M44)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Equality =
         //
         [<Property>]
@@ -103,7 +103,7 @@ module Matrix4 =
         let ``A matrix is not equal to an object which is not a matrix`` (a : Matrix4, b : Vector3) =
             Assert.False(a.Equals(b))
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Multiplication =
         //
         [<Property>]
@@ -202,7 +202,7 @@ module Matrix4 =
             Assert.Equal(R4, AScaled.Row3)
 
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Addition =
         //
         [<Property>]
@@ -232,7 +232,7 @@ module Matrix4 =
             Assert.Equal(o + o, sum.M43)
             Assert.Equal(p + p, sum.M44)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Subtraction =
         //
         [<Property>]
@@ -262,7 +262,7 @@ module Matrix4 =
             Assert.Equal(o - o, sub.M43)
             Assert.Equal(p - p, sub.M44)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Indexing =
         //
         [<Property>]
@@ -363,7 +363,7 @@ module Matrix4 =
             (fun() -> a.[1, 6] |> ignore) |> Assert.ThrowsIndexExn
             (fun() -> a.[7, 12] |> ignore) |> Assert.ThrowsIndexExn
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Row and column properties`` =
         //
         [<Property>]

--- a/tests/OpenTK.Tests/Vector2Tests.fs
+++ b/tests/OpenTK.Tests/Vector2Tests.fs
@@ -8,7 +8,7 @@ open System.Runtime.InteropServices
 open OpenTK
 
 module Vector2 =
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Constructors =
         //
         [<Property>]
@@ -23,7 +23,7 @@ module Vector2 =
             Assert.Equal(x,v.X)
             Assert.Equal(y,v.Y)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Clamping =
         //
         [<Property>]
@@ -46,7 +46,7 @@ module Vector2 =
             Assert.Equal(expX, res.X)
             Assert.Equal(expY, res.Y)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Length =
         //
         [<Property>]
@@ -75,7 +75,7 @@ module Vector2 =
 
             Assert.Equal(lsq, v.LengthSquared)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Unit vectors and perpendicularity`` =
         //
         [<Property>]
@@ -92,7 +92,7 @@ module Vector2 =
 
             Assert.Equal(perp, v.PerpendicularLeft)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Indexing =
         //
         [<Property>]
@@ -126,7 +126,7 @@ module Vector2 =
 
             (fun() -> v.[2] |> ignore) |> Assert.ThrowsIndexExn
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Simple Properties`` =
         //
         [<Property>]
@@ -139,26 +139,26 @@ module Vector2 =
             //
             Assert.True(a.Length >= 0.0f)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Addition =
         //
         [<Property>]
         let ``Vector addition is the same as component addition`` (a : Vector2,b : Vector2) =
             let c = a + b
-            Assert.ApproximatelyEqual(a.X + b.X,c.X)
-            Assert.ApproximatelyEqual(a.Y + b.Y,c.Y)
+            Assert.ApproximatelyEquivalent(a.X + b.X,c.X)
+            Assert.ApproximatelyEquivalent(a.Y + b.Y,c.Y)
 
         [<Property>]
         let ``Vector addition is commutative`` (a : Vector2,b : Vector2) =
             let c = a + b
             let c2 = b + a
-            Assert.ApproximatelyEqual(c,c2)
+            Assert.ApproximatelyEquivalent(c,c2)
 
         [<Property>]
         let ``Vector addition is associative`` (a : Vector2,b : Vector2,c : Vector2) =
             let r1 = (a + b) + c
             let r2 = a + (b + c)
-            Assert.ApproximatelyEqual(r1,r2)
+            Assert.ApproximatelyEquivalent(r1,r2)
 
         [<Property>]
         let ``Static Vector2 addition method is the same as component addition`` (a : Vector2, b : Vector2) =
@@ -166,7 +166,7 @@ module Vector2 =
             let v1 = Vector2(a.X + b.X, a.Y + b.Y)
             let sum = Vector2.Add(a, b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector2 addition method by reference is the same as component addition`` (a : Vector2, b : Vector2) =
@@ -174,9 +174,9 @@ module Vector2 =
             let v1 = Vector2(a.X + b.X, a.Y + b.Y)
             let sum = Vector2.Add(ref a, ref b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Multiplication =
         //
         [<Property>]
@@ -210,7 +210,7 @@ module Vector2 =
             let v1 = Vector2(a.X * b.X, a.Y * b.Y)
             let sum = Vector2.Multiply(a, b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector2 multiplication method by reference is the same as component multiplication`` (a : Vector2, b : Vector2) =
@@ -218,7 +218,7 @@ module Vector2 =
             let v1 = Vector2(a.X * b.X, a.Y * b.Y)
             let sum = Vector2.Multiply(ref a, ref b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static method Vector2-scalar multiplication is the same as component-scalar multiplication`` (a : Vector2, f : float32) =
@@ -227,7 +227,7 @@ module Vector2 =
             Assert.Equal(a.X * f,r.X)
             Assert.Equal(a.Y * f,r.Y)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Subtraction =
         //
         [<Property>]
@@ -242,7 +242,7 @@ module Vector2 =
             let v1 = Vector2(a.X - b.X, a.Y - b.Y)
             let sum = Vector2.Subtract(a, b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector2 subtraction method by reference is the same as component addition`` (a : Vector2, b : Vector2) =
@@ -250,9 +250,9 @@ module Vector2 =
             let v1 = Vector2(a.X - b.X, a.Y - b.Y)
             let sum = Vector2.Subtract(ref a, ref b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Division =
         //
         [<Property>]
@@ -260,8 +260,8 @@ module Vector2 =
             if not (approxEq f 0.0f) then
                 let r = a / f
 
-                Assert.ApproximatelyEqual(a.X / f,r.X)
-                Assert.ApproximatelyEqual(a.Y / f,r.Y)
+                Assert.ApproximatelyEquivalent(a.X / f,r.X)
+                Assert.ApproximatelyEquivalent(a.Y / f,r.Y)
 
         [<Property>]
         let ``Static Vector2-Vector2 division method is the same as component division`` (a : Vector2, b : Vector2) =
@@ -269,7 +269,7 @@ module Vector2 =
                 let v1 = Vector2(a.X / b.X, a.Y / b.Y)
                 let sum = Vector2.Divide(a, b)
 
-                Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector2-Vector2 divison method by reference `` (a : Vector2, b : Vector2) =
@@ -277,7 +277,7 @@ module Vector2 =
                 let v1 = Vector2(a.X / b.X, a.Y / b.Y)
                 let sum = Vector2.Divide(ref a, ref b)
 
-                Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector2-scalar division method is the same as component division`` (a : Vector2, b : float32) =
@@ -285,7 +285,7 @@ module Vector2 =
                 let v1 = Vector2(a.X / b, a.Y / b)
                 let sum = Vector2.Divide(a, b)
 
-                Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector2-scalar divison method by reference is the same as component division`` (a : Vector2, b : float32) =
@@ -293,9 +293,9 @@ module Vector2 =
                 let v1 = Vector2(a.X / b, a.Y / b)
                 let sum = Vector2.Divide(ref a, b)
 
-                Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEquivalent(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Negation =
         //
         [<Property>]
@@ -305,7 +305,7 @@ module Vector2 =
             Assert.Equal(-x, vNeg.X)
             Assert.Equal(-y, vNeg.Y)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Equality =
         //
         [<Property>]
@@ -336,7 +336,7 @@ module Vector2 =
             Assert.True(equality)
             Assert.False(inequalityByOtherType)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Swizzling =
         //
         [<Property>]
@@ -347,7 +347,7 @@ module Vector2 =
             let v1yx = v1.Yx;
             Assert.Equal(v2, v1yx);
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Interpolation =
         //
         [<Property>]
@@ -374,7 +374,7 @@ module Vector2 =
             let vRes = Vector2.BaryCentric(ref a, ref b, ref c, u, v)
             Assert.Equal(r, vRes)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Vector products`` =
         //
         [<Property>]
@@ -395,7 +395,7 @@ module Vector2 =
             let vRes = Vector2.PerpDot(ref a, ref b)
             Assert.Equal(perpDot, vRes)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Normalization =
         //
         [<Property>]
@@ -407,8 +407,8 @@ module Vector2 =
             if not (approxEq l 0.0f) then
                 let norm = v.Normalized()
 
-                Assert.ApproximatelyEqual(v.X / l, norm.X)
-                Assert.ApproximatelyEqual(v.Y / l, norm.Y)
+                Assert.ApproximatelyEquivalent(v.X / l, norm.X)
+                Assert.ApproximatelyEquivalent(v.Y / l, norm.Y)
 
         [<Property>]
         let ``Normalization of instance transforms the instance into a unit length vector with the correct components`` (a, b) =
@@ -419,8 +419,8 @@ module Vector2 =
                 let norm = Vector2(a, b)
                 norm.Normalize()
 
-                Assert.ApproximatelyEqual(v.X / l, norm.X)
-                Assert.ApproximatelyEqual(v.Y / l, norm.Y)
+                Assert.ApproximatelyEquivalent(v.X / l, norm.X)
+                Assert.ApproximatelyEquivalent(v.Y / l, norm.Y)
 
         [<Property>]
         let ``Fast approximate normalization of instance transforms the instance into a unit length vector with the correct components`` (a, b) =
@@ -430,8 +430,8 @@ module Vector2 =
 
             let scale = MathHelper.InverseSqrtFast(a * a + b * b)
 
-            Assert.ApproximatelyEqual(v.X * scale, norm.X)
-            Assert.ApproximatelyEqual(v.Y * scale, norm.Y)
+            Assert.ApproximatelyEquivalent(v.X * scale, norm.X)
+            Assert.ApproximatelyEquivalent(v.Y * scale, norm.Y)
 
         [<Property>]
         let ``Normalization by reference is the same as division by magnitude`` (a : Vector2) =
@@ -440,7 +440,7 @@ module Vector2 =
                 let norm = a / a.Length
                 let vRes = Vector2.Normalize(ref a)
 
-                Assert.ApproximatelyEqual(norm, vRes)
+                Assert.ApproximatelyEquivalent(norm, vRes)
 
         [<Property>]
         let ``Normalization is the same as division by magnitude`` (a : Vector2) =
@@ -448,7 +448,7 @@ module Vector2 =
             if not (approxEq a.Length 0.0f) then
                 let norm = a / a.Length
 
-                Assert.ApproximatelyEqual(norm, Vector2.Normalize(a));
+                Assert.ApproximatelyEquivalent(norm, Vector2.Normalize(a));
 
         [<Property>]
         let ``Fast approximate normalization by reference is the same as multiplication by the fast inverse square`` (a : Vector2) =
@@ -457,7 +457,7 @@ module Vector2 =
             let norm = a * scale
             let vRes = Vector2.NormalizeFast(ref a)
 
-            Assert.ApproximatelyEqual(norm, vRes)
+            Assert.ApproximatelyEquivalent(norm, vRes)
 
         [<Property>]
         let ``Fast approximate normalization is the same as multiplication by the fast inverse square`` (a : Vector2) =
@@ -465,9 +465,9 @@ module Vector2 =
 
             let norm = a * scale
 
-            Assert.ApproximatelyEqual(norm, Vector2.NormalizeFast(a));
+            Assert.ApproximatelyEquivalent(norm, Vector2.NormalizeFast(a));
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Magnitude min and max`` =
         //
         [<Property>]
@@ -534,7 +534,7 @@ module Vector2 =
                     let v2LongerThanv1 = l2 > l1
                     Assert.True(v2LongerThanv1)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Component min and max`` =
         //
         [<Property>]
@@ -569,7 +569,7 @@ module Vector2 =
             Assert.True(isComponentLargest vMax.X v1.X v2.X)
             Assert.True(isComponentLargest vMax.Y v1.Y v2.Y)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Transformation =
         //
         [<Property>]
@@ -580,7 +580,7 @@ module Vector2 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = Vector2(transformedQuat.X, transformedQuat.Y)
 
-            Assert.ApproximatelyEqual(transformedVector, Vector2.Transform(v, q))
+            Assert.ApproximatelyEquivalent(transformedVector, Vector2.Transform(v, q))
 
         [<Property>]
         let ``Transformation by quaternion by reference is the same as multiplication by quaternion and its conjugate`` (v : Vector2, q : Quaternion) =
@@ -590,9 +590,9 @@ module Vector2 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = Vector2(transformedQuat.X, transformedQuat.Y)
 
-            Assert.ApproximatelyEqual(transformedVector, Vector2.Transform(ref v, ref q))
+            Assert.ApproximatelyEquivalent(transformedVector, Vector2.Transform(ref v, ref q))
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Serialization =
         //
         [<Property>]

--- a/tests/OpenTK.Tests/Vector2Tests.fs
+++ b/tests/OpenTK.Tests/Vector2Tests.fs
@@ -567,7 +567,7 @@ module Vector2 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = Vector2(transformedQuat.X, transformedQuat.Y)
 
-            Assert.Equal(transformedVector, Vector2.Transform(v, q))
+            Assert.ApproximatelyEqual(transformedVector, Vector2.Transform(v, q))
 
         [<Property>]
         let ``Transformation by quaternion by reference is the same as multiplication by quaternion and its conjugate`` (v : Vector2, q : Quaternion) =
@@ -577,7 +577,7 @@ module Vector2 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = Vector2(transformedQuat.X, transformedQuat.Y)
 
-            Assert.Equal(transformedVector, Vector2.Transform(ref v, ref q))
+            Assert.ApproximatelyEqual(transformedVector, Vector2.Transform(ref v, ref q))
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Serialization =

--- a/tests/OpenTK.Tests/Vector2Tests.fs
+++ b/tests/OpenTK.Tests/Vector2Tests.fs
@@ -8,7 +8,7 @@ open System.Runtime.InteropServices
 open OpenTK
 
 module Vector2 =
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Constructors =
         //
         [<Property>]
@@ -23,7 +23,7 @@ module Vector2 =
             Assert.Equal(x,v.X)
             Assert.Equal(y,v.Y)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Clamping =
         //
         [<Property>]
@@ -46,7 +46,7 @@ module Vector2 =
             Assert.Equal(expX, res.X)
             Assert.Equal(expY, res.Y)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Length =
         //
         [<Property>]
@@ -75,7 +75,7 @@ module Vector2 =
 
             Assert.Equal(lsq, v.LengthSquared)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Unit vectors and perpendicularity`` =
         //
         [<Property>]
@@ -92,7 +92,7 @@ module Vector2 =
 
             Assert.Equal(perp, v.PerpendicularLeft)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Indexing =
         //
         [<Property>]
@@ -126,7 +126,7 @@ module Vector2 =
 
             (fun() -> v.[2] |> ignore) |> Assert.ThrowsIndexExn
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Simple Properties`` =
         //
         [<Property>]
@@ -139,7 +139,7 @@ module Vector2 =
             //
             Assert.True(a.Length >= 0.0f)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Addition =
         //
         [<Property>]
@@ -176,7 +176,7 @@ module Vector2 =
 
             Assert.ApproximatelyEqual(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Multiplication =
         //
         [<Property>]
@@ -227,7 +227,7 @@ module Vector2 =
             Assert.Equal(a.X * f,r.X)
             Assert.Equal(a.Y * f,r.Y)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Subtraction =
         //
         [<Property>]
@@ -252,49 +252,50 @@ module Vector2 =
 
             Assert.ApproximatelyEqual(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Division =
         //
         [<Property>]
         let ``Vector2-float division is the same as component-float division`` (a : Vector2, f : float32) =
-            let r = a / f
+            if not (approxEq f 0.0f) then
+                let r = a / f
 
-            Assert.ApproximatelyEqual(a.X / f,r.X)
-            Assert.ApproximatelyEqual(a.Y / f,r.Y)
+                Assert.ApproximatelyEqual(a.X / f,r.X)
+                Assert.ApproximatelyEqual(a.Y / f,r.Y)
 
         [<Property>]
         let ``Static Vector2-Vector2 division method is the same as component division`` (a : Vector2, b : Vector2) =
+            if not (anyZero2 a || anyZero2 b) then
+                let v1 = Vector2(a.X / b.X, a.Y / b.Y)
+                let sum = Vector2.Divide(a, b)
 
-            let v1 = Vector2(a.X / b.X, a.Y / b.Y)
-            let sum = Vector2.Divide(a, b)
-
-            Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEqual(v1, sum)
 
         [<Property>]
         let ``Static Vector2-Vector2 divison method by reference `` (a : Vector2, b : Vector2) =
+            if not (anyZero2 a || anyZero2 b) then
+                let v1 = Vector2(a.X / b.X, a.Y / b.Y)
+                let sum = Vector2.Divide(ref a, ref b)
 
-            let v1 = Vector2(a.X / b.X, a.Y / b.Y)
-            let sum = Vector2.Divide(ref a, ref b)
-
-            Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEqual(v1, sum)
 
         [<Property>]
         let ``Static Vector2-scalar division method is the same as component division`` (a : Vector2, b : float32) =
+            if not (approxEq b 0.0f) then
+                let v1 = Vector2(a.X / b, a.Y / b)
+                let sum = Vector2.Divide(a, b)
 
-            let v1 = Vector2(a.X / b, a.Y / b)
-            let sum = Vector2.Divide(a, b)
-
-            Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEqual(v1, sum)
 
         [<Property>]
         let ``Static Vector2-scalar divison method by reference is the same as component division`` (a : Vector2, b : float32) =
+            if not (approxEq b 0.0f) then
+                let v1 = Vector2(a.X / b, a.Y / b)
+                let sum = Vector2.Divide(ref a, b)
 
-            let v1 = Vector2(a.X / b, a.Y / b)
-            let sum = Vector2.Divide(ref a, b)
+                Assert.ApproximatelyEqual(v1, sum)
 
-            Assert.ApproximatelyEqual(v1, sum)
-
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Negation =
         //
         [<Property>]
@@ -304,7 +305,7 @@ module Vector2 =
             Assert.Equal(-x, vNeg.X)
             Assert.Equal(-y, vNeg.Y)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Equality =
         //
         [<Property>]
@@ -335,7 +336,7 @@ module Vector2 =
             Assert.True(equality)
             Assert.False(inequalityByOtherType)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Swizzling =
         //
         [<Property>]
@@ -346,7 +347,7 @@ module Vector2 =
             let v1yx = v1.Yx;
             Assert.Equal(v2, v1yx);
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Interpolation =
         //
         [<Property>]
@@ -373,7 +374,7 @@ module Vector2 =
             let vRes = Vector2.BaryCentric(ref a, ref b, ref c, u, v)
             Assert.Equal(r, vRes)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Vector products`` =
         //
         [<Property>]
@@ -394,7 +395,7 @@ module Vector2 =
             let vRes = Vector2.PerpDot(ref a, ref b)
             Assert.Equal(perpDot, vRes)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Normalization =
         //
         [<Property>]
@@ -434,16 +435,20 @@ module Vector2 =
 
         [<Property>]
         let ``Normalization by reference is the same as division by magnitude`` (a : Vector2) =
-            let norm = a / a.Length
-            let vRes = Vector2.Normalize(ref a)
+            // Zero-length vectors can't be normalized
+            if not (approxEq a.Length 0.0f) then
+                let norm = a / a.Length
+                let vRes = Vector2.Normalize(ref a)
 
-            Assert.ApproximatelyEqual(norm, vRes)
+                Assert.ApproximatelyEqual(norm, vRes)
 
         [<Property>]
         let ``Normalization is the same as division by magnitude`` (a : Vector2) =
-            let norm = a / a.Length
+            // Zero-length vectors can't be normalized
+            if not (approxEq a.Length 0.0f) then
+                let norm = a / a.Length
 
-            Assert.ApproximatelyEqual(norm, Vector2.Normalize(a));
+                Assert.ApproximatelyEqual(norm, Vector2.Normalize(a));
 
         [<Property>]
         let ``Fast approximate normalization by reference is the same as multiplication by the fast inverse square`` (a : Vector2) =
@@ -462,66 +467,74 @@ module Vector2 =
 
             Assert.ApproximatelyEqual(norm, Vector2.NormalizeFast(a));
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Magnitude min and max`` =
         //
         [<Property>]
         let ``MagnitudeMin selects the vector with equal or lesser magnitude given two vectors`` (v1 : Vector2, v2: Vector2) =
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
+            // Results do not matter for equal vectors
+            if not (v1 = v2) then
+                let l1 = v1.LengthSquared
+                let l2 = v2.LengthSquared
 
-            let vMin = Vector2.MagnitudeMin(v1, v2)
+                let vMin = Vector2.MagnitudeMin(v1, v2)
 
-            if vMin = v1 then
-                let v1ShorterThanv2 = l1 < l2
-                Assert.True(v1ShorterThanv2)
-            else
-                let v2ShorterThanOrEqualTov1 = l2 <= l1
-                Assert.True(v2ShorterThanOrEqualTov1)
+                if vMin = v1 then
+                    let v1ShorterThanv2 = l1 < l2
+                    Assert.True(v1ShorterThanv2)
+                else
+                    let v2ShorterThanOrEqualTov1 = l2 <= l1
+                    Assert.True(v2ShorterThanOrEqualTov1)
 
         [<Property>]
         let ``MagnitudeMax selects the vector with equal or greater magnitude given two vectors`` (v1 : Vector2, v2: Vector2) =
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
+            // Results do not matter for equal vectors
+            if not (v1 = v2) then
+                let l1 = v1.LengthSquared
+                let l2 = v2.LengthSquared
 
-            let vMin = Vector2.MagnitudeMax(v1, v2)
+                let vMin = Vector2.MagnitudeMax(v1, v2)
 
-            if vMin = v1 then
-                let v1LongerThanOrEqualTov2 = l1 >= l2
-                Assert.True(v1LongerThanOrEqualTov2)
-            else
-                let v2LongerThanv1 = l2 > l1
-                Assert.True(v2LongerThanv1)
+                if vMin = v1 then
+                    let v1LongerThanOrEqualTov2 = l1 >= l2
+                    Assert.True(v1LongerThanOrEqualTov2)
+                else
+                    let v2LongerThanv1 = l2 > l1
+                    Assert.True(v2LongerThanv1)
 
         [<Property>]
         let ``MagnitudeMin by reference selects the vector with equal or lesser magnitude given two vectors`` (v1 : Vector2, v2: Vector2) =
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
+            // Results do not matter for equal vectors
+            if not (v1 = v2) then
+                let l1 = v1.LengthSquared
+                let l2 = v2.LengthSquared
 
-            let vMin = Vector2.MagnitudeMin(ref v1, ref v2)
+                let vMin = Vector2.MagnitudeMin(ref v1, ref v2)
 
-            if vMin = v1 then
-                let v1ShorterThanv2 = l1 < l2
-                Assert.True(v1ShorterThanv2)
-            else
-                let v2ShorterThanOrEqualTov1 = l2 <= l1
-                Assert.True(v2ShorterThanOrEqualTov1)
+                if vMin = v1 then
+                    let v1ShorterThanv2 = l1 < l2
+                    Assert.True(v1ShorterThanv2)
+                else
+                    let v2ShorterThanOrEqualTov1 = l2 <= l1
+                    Assert.True(v2ShorterThanOrEqualTov1)
 
         [<Property>]
         let ``MagnitudeMax by reference selects the vector with equal greater magnitude given two vectors`` (v1 : Vector2, v2: Vector2) =
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
+            // Results do not matter for equal vectors
+            if not (v1 = v2) then
+                let l1 = v1.LengthSquared
+                let l2 = v2.LengthSquared
 
-            let vMin = Vector2.MagnitudeMax(ref v1, ref v2)
+                let vMin = Vector2.MagnitudeMax(ref v1, ref v2)
 
-            if vMin = v1 then
-                let v1LongerThanOrEqualTov2 = l1 >= l2
-                Assert.True(v1LongerThanOrEqualTov2)
-            else
-                let v2LongerThanv1 = l2 > l1
-                Assert.True(v2LongerThanv1)
+                if vMin = v1 then
+                    let v1LongerThanOrEqualTov2 = l1 >= l2
+                    Assert.True(v1LongerThanOrEqualTov2)
+                else
+                    let v2LongerThanv1 = l2 > l1
+                    Assert.True(v2LongerThanv1)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Component min and max`` =
         //
         [<Property>]
@@ -556,7 +569,7 @@ module Vector2 =
             Assert.True(isComponentLargest vMax.X v1.X v2.X)
             Assert.True(isComponentLargest vMax.Y v1.Y v2.Y)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Transformation =
         //
         [<Property>]
@@ -579,7 +592,7 @@ module Vector2 =
 
             Assert.ApproximatelyEqual(transformedVector, Vector2.Transform(ref v, ref q))
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Serialization =
         //
         [<Property>]

--- a/tests/OpenTK.Tests/Vector3Tests.fs
+++ b/tests/OpenTK.Tests/Vector3Tests.fs
@@ -8,7 +8,7 @@ open System.Runtime.InteropServices
 open OpenTK
 
 module Vector3 =
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Constructors =
         //
         [<Property>]
@@ -65,7 +65,7 @@ module Vector3 =
             Assert.Equal(b, v2.Y)
             Assert.Equal(c, v2.Z)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Indexing =
         //
         [<Property>]
@@ -100,7 +100,7 @@ module Vector3 =
 
             (fun() -> v.[4] |> ignore) |> Assert.ThrowsIndexExn
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Length =
         //
         [<Property>]
@@ -124,7 +124,7 @@ module Vector3 =
 
             Assert.Equal(lsq, v.LengthSquared)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Normalization =
         //
         [<Property>]
@@ -136,9 +136,9 @@ module Vector3 =
             if not (approxEq l 0.0f) then
                 let norm = v.Normalized()
 
-                Assert.ApproximatelyEqual(v.X / l, norm.X)
-                Assert.ApproximatelyEqual(v.Y / l, norm.Y)
-                Assert.ApproximatelyEqual(v.Z / l, norm.Z)
+                Assert.ApproximatelyEquivalent(v.X / l, norm.X)
+                Assert.ApproximatelyEquivalent(v.Y / l, norm.Y)
+                Assert.ApproximatelyEquivalent(v.Z / l, norm.Z)
 
         [<Property>]
         let ``Normalization of instance transforms the instance into a unit length vector with the correct components`` (a, b, c) =
@@ -149,9 +149,9 @@ module Vector3 =
                 let norm = Vector3(a, b, c)
                 norm.Normalize()
 
-                Assert.ApproximatelyEqual(v.X / l, norm.X)
-                Assert.ApproximatelyEqual(v.Y / l, norm.Y)
-                Assert.ApproximatelyEqual(v.Z / l, norm.Z)
+                Assert.ApproximatelyEquivalent(v.X / l, norm.X)
+                Assert.ApproximatelyEquivalent(v.Y / l, norm.Y)
+                Assert.ApproximatelyEquivalent(v.Z / l, norm.Z)
 
         [<Property>]
         let ``Fast approximate normalization of instance transforms the instance into a unit length vector with the correct components`` (a, b, c) =
@@ -161,9 +161,9 @@ module Vector3 =
 
             let scale = MathHelper.InverseSqrtFast(a * a + b * b + c * c)
 
-            Assert.ApproximatelyEqual(v.X * scale, norm.X)
-            Assert.ApproximatelyEqual(v.Y * scale, norm.Y)
-            Assert.ApproximatelyEqual(v.Z * scale, norm.Z)
+            Assert.ApproximatelyEquivalent(v.X * scale, norm.X)
+            Assert.ApproximatelyEquivalent(v.Y * scale, norm.Y)
+            Assert.ApproximatelyEquivalent(v.Z * scale, norm.Z)
 
         [<Property>]
         let ``Normalization by reference is the same as division by magnitude`` (a : Vector3) =
@@ -172,7 +172,7 @@ module Vector3 =
                 let norm = a / a.Length
                 let vRes = Vector3.Normalize(ref a)
 
-                Assert.ApproximatelyEqual(norm, vRes)
+                Assert.ApproximatelyEquivalent(norm, vRes)
 
         [<Property>]
         let ``Normalization is the same as division by magnitude`` (a : Vector3) =
@@ -180,7 +180,7 @@ module Vector3 =
             if not (approxEq a.Length 0.0f) then
                 let norm = a / a.Length
 
-                Assert.ApproximatelyEqual(norm, Vector3.Normalize(a));
+                Assert.ApproximatelyEquivalent(norm, Vector3.Normalize(a));
 
         [<Property>]
         let ``Fast approximate normalization by reference is the same as multiplication by the fast inverse square`` (a : Vector3) =
@@ -189,7 +189,7 @@ module Vector3 =
             let norm = a * scale
             let vRes = Vector3.NormalizeFast(ref a)
 
-            Assert.ApproximatelyEqual(norm, vRes)
+            Assert.ApproximatelyEquivalent(norm, vRes)
 
         [<Property>]
         let ``Fast approximate normalization is the same as multiplication by fast inverse square`` (a : Vector3) =
@@ -197,32 +197,32 @@ module Vector3 =
 
             let norm = a * scale
 
-            Assert.ApproximatelyEqual(norm, Vector3.NormalizeFast(a));
+            Assert.ApproximatelyEquivalent(norm, Vector3.NormalizeFast(a));
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Addition =
         //
         [<Property>]
         let ``Vector3 addition is the same as component addition`` (a : Vector3, b : Vector3) =
             let c = a + b
 
-            Assert.ApproximatelyEqual(a.X + b.X,c.X)
-            Assert.ApproximatelyEqual(a.Y + b.Y,c.Y)
-            Assert.ApproximatelyEqual(a.Z + b.Z,c.Z)
+            Assert.ApproximatelyEquivalent(a.X + b.X,c.X)
+            Assert.ApproximatelyEquivalent(a.Y + b.Y,c.Y)
+            Assert.ApproximatelyEquivalent(a.Z + b.Z,c.Z)
 
         [<Property>]
         let ``Vector3 addition is commutative`` (a : Vector3, b : Vector3) =
             let c = a + b
             let c2 = b + a
 
-            Assert.ApproximatelyEqual(c, c2)
+            Assert.ApproximatelyEquivalent(c, c2)
 
         [<Property>]
         let ``Vector3 addition is associative`` (a : Vector3, b : Vector3, c : Vector3) =
             let r1 = (a + b) + c
             let r2 = a + (b + c)
 
-            Assert.ApproximatelyEqual(r1, r2)
+            Assert.ApproximatelyEquivalent(r1, r2)
 
         [<Property>]
         let ``Static Vector3 addition method is the same as component addition`` (a : Vector3, b : Vector3) =
@@ -230,7 +230,7 @@ module Vector3 =
             let v1 = Vector3(a.X + b.X, a.Y + b.Y, a.Z + b.Z)
             let sum = Vector3.Add(a, b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector3 addition method by reference is the same as component addition`` (a : Vector3, b : Vector3) =
@@ -238,9 +238,9 @@ module Vector3 =
             let v1 = Vector3(a.X + b.X, a.Y + b.Y, a.Z + b.Z)
             let sum = Vector3.Add(ref a, ref b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Subtraction =
         //
         [<Property>]
@@ -257,7 +257,7 @@ module Vector3 =
             let v1 = Vector3(a.X - b.X, a.Y - b.Y, a.Z - b.Z)
             let sum = Vector3.Subtract(a, b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector3 subtraction method by reference is the same as component addition`` (a : Vector3, b : Vector3) =
@@ -265,9 +265,9 @@ module Vector3 =
             let v1 = Vector3(a.X - b.X, a.Y - b.Y, a.Z - b.Z)
             let sum = Vector3.Subtract(ref a, ref b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Multiplication =
         //
         [<Property>]
@@ -338,7 +338,7 @@ module Vector3 =
             let v1 = Vector3(a.X * b.X, a.Y * b.Y, a.Z * b.Z)
             let sum = Vector3.Multiply(a, b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector3 multiplication method by reference is the same as component multiplication`` (a : Vector3, b : Vector3) =
@@ -346,9 +346,9 @@ module Vector3 =
             let v1 = Vector3(a.X * b.X, a.Y * b.Y, a.Z * b.Z)
             let sum = Vector3.Multiply(ref a, ref b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Division =
         //
         [<Property>]
@@ -356,9 +356,9 @@ module Vector3 =
             if not (approxEq f 0.0f) then // we don't support diving by zero.
                 let r = a / f
 
-                Assert.ApproximatelyEqual(a.X / f,r.X)
-                Assert.ApproximatelyEqual(a.Y / f,r.Y)
-                Assert.ApproximatelyEqual(a.Z / f,r.Z)
+                Assert.ApproximatelyEquivalent(a.X / f,r.X)
+                Assert.ApproximatelyEquivalent(a.Y / f,r.Y)
+                Assert.ApproximatelyEquivalent(a.Z / f,r.Z)
 
         [<Property>]
         let ``Static Vector3-Vector3 division method is the same as component division`` (a : Vector3, b : Vector3) =
@@ -366,7 +366,7 @@ module Vector3 =
                 let v1 = Vector3(a.X / b.X, a.Y / b.Y, a.Z / b.Z)
                 let sum = Vector3.Divide(a, b)
 
-                Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector3-Vector3 divison method by reference is the same as component division`` (a : Vector3, b : Vector3) =
@@ -374,7 +374,7 @@ module Vector3 =
                 let v1 = Vector3(a.X / b.X, a.Y / b.Y, a.Z / b.Z)
                 let sum = Vector3.Divide(ref a, ref b)
 
-                Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector3-scalar division method is the same as component division`` (a : Vector3, b : float32) =
@@ -382,7 +382,7 @@ module Vector3 =
                 let v1 = Vector3(a.X / b, a.Y / b, a.Z / b)
                 let sum = Vector3.Divide(a, b)
 
-                Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector3-scalar divison method by reference is the same as component division`` (a : Vector3, b : float32) =
@@ -390,9 +390,9 @@ module Vector3 =
                 let v1 = Vector3(a.X / b, a.Y / b, a.Z / b)
                 let sum = Vector3.Divide(ref a, b)
 
-                Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEquivalent(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Negation =
         //
         [<Property>]
@@ -403,7 +403,7 @@ module Vector3 =
             Assert.Equal(-y, vNeg.Y)
             Assert.Equal(-z, vNeg.Z)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Equality =
         //
         [<Property>]
@@ -434,7 +434,7 @@ module Vector3 =
             Assert.True(equality)
             Assert.False(inequalityByOtherType)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Swizzling =
         //
         [<Property>]
@@ -479,7 +479,7 @@ module Vector3 =
             Assert.Equal(zx, v.Zx);
             Assert.Equal(zy, v.Zy);
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Interpolation =
         //
         [<Property>]
@@ -507,7 +507,7 @@ module Vector3 =
             let vRes = Vector3.BaryCentric(ref a, ref b, ref c, u, v)
             Assert.Equal(r, vRes)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Vector products`` =
         //
         [<Property>]
@@ -531,7 +531,7 @@ module Vector3 =
             let vRes = Vector3.Cross(ref a, ref b)
             Assert.Equal(cross, vRes)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Magnitude min and max`` =
         //
         [<Property>]
@@ -598,7 +598,7 @@ module Vector3 =
                     let v2LongerThanv1 = l2 > l1
                     Assert.True(v2LongerThanv1)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Component min and max`` =
         //
         [<Property>]
@@ -637,7 +637,7 @@ module Vector3 =
             Assert.True(isComponentLargest vMax.Y v1.Y v2.Y)
             Assert.True(isComponentLargest vMax.Z v1.Z v2.Z)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Clamping =
         //
         [<Property>]
@@ -664,7 +664,7 @@ module Vector3 =
             Assert.Equal(expY, res.Y)
             Assert.Equal(expZ, res.Z)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Unit vectors``=
         //
         [<Property>]
@@ -697,7 +697,7 @@ module Vector3 =
 
             Assert.Equal(Vector3.One, unitOne)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Serialization =
         //
         [<Property>]
@@ -707,7 +707,7 @@ module Vector3 =
             Assert.Equal(expectedSize, Vector3.SizeInBytes)
             Assert.Equal(expectedSize, Marshal.SizeOf(Vector3()))
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Transformation =
         //
         [<Property>]
@@ -718,7 +718,7 @@ module Vector3 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = transformedQuat.Xyz
 
-            Assert.ApproximatelyEqual(transformedVector, Vector3.Transform(v, q))
+            Assert.ApproximatelyEquivalent(transformedVector, Vector3.Transform(v, q))
 
         [<Property>]
         let ``Transformation by quaternion by reference is the same as multiplication by quaternion and its conjugate`` (v : Vector3, q : Quaternion) =
@@ -728,7 +728,7 @@ module Vector3 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = transformedQuat.Xyz
 
-            Assert.ApproximatelyEqual(transformedVector, Vector3.Transform(ref v, ref q))
+            Assert.ApproximatelyEquivalent(transformedVector, Vector3.Transform(ref v, ref q))
 
         [<Property>]
         let ``Transformation by quaternion by multiplication using right-handed notation is the same as multiplication by quaternion and its conjugate`` (v : Vector3, q : Quaternion) =
@@ -738,7 +738,7 @@ module Vector3 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = transformedQuat.Xyz
 
-            Assert.ApproximatelyEqual(transformedVector, q * v)
+            Assert.ApproximatelyEquivalent(transformedVector, q * v)
 
         [<Property>]
         let ``Transformation by identity quaternion does not alter vector`` (v : Vector3) =
@@ -749,6 +749,6 @@ module Vector3 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = transformedQuat.Xyz
 
-            Assert.ApproximatelyEqual(v, transformedVector)
-            Assert.ApproximatelyEqual(v, Vector3.Transform(v, q))
-            Assert.ApproximatelyEqual(transformedVector, Vector3.Transform(v, q))
+            Assert.ApproximatelyEquivalent(v, transformedVector)
+            Assert.ApproximatelyEquivalent(v, Vector3.Transform(v, q))
+            Assert.ApproximatelyEquivalent(transformedVector, Vector3.Transform(v, q))

--- a/tests/OpenTK.Tests/Vector3Tests.fs
+++ b/tests/OpenTK.Tests/Vector3Tests.fs
@@ -8,7 +8,7 @@ open System.Runtime.InteropServices
 open OpenTK
 
 module Vector3 =
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Constructors =
         //
         [<Property>]
@@ -65,7 +65,7 @@ module Vector3 =
             Assert.Equal(b, v2.Y)
             Assert.Equal(c, v2.Z)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Indexing =
         //
         [<Property>]
@@ -100,7 +100,7 @@ module Vector3 =
 
             (fun() -> v.[4] |> ignore) |> Assert.ThrowsIndexExn
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Length =
         //
         [<Property>]
@@ -124,7 +124,7 @@ module Vector3 =
 
             Assert.Equal(lsq, v.LengthSquared)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Normalization =
         //
         [<Property>]
@@ -167,16 +167,20 @@ module Vector3 =
 
         [<Property>]
         let ``Normalization by reference is the same as division by magnitude`` (a : Vector3) =
-            let norm = a / a.Length
-            let vRes = Vector3.Normalize(ref a)
+            // Zero-length vectors can't be normalized
+            if not (approxEq a.Length 0.0f) then
+                let norm = a / a.Length
+                let vRes = Vector3.Normalize(ref a)
 
-            Assert.ApproximatelyEqual(norm, vRes)
+                Assert.ApproximatelyEqual(norm, vRes)
 
         [<Property>]
         let ``Normalization is the same as division by magnitude`` (a : Vector3) =
-            let norm = a / a.Length
+            // Zero-length vectors can't be normalized
+            if not (approxEq a.Length 0.0f) then
+                let norm = a / a.Length
 
-            Assert.ApproximatelyEqual(norm, Vector3.Normalize(a));
+                Assert.ApproximatelyEqual(norm, Vector3.Normalize(a));
 
         [<Property>]
         let ``Fast approximate normalization by reference is the same as multiplication by the fast inverse square`` (a : Vector3) =
@@ -195,7 +199,7 @@ module Vector3 =
 
             Assert.ApproximatelyEqual(norm, Vector3.NormalizeFast(a));
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Addition =
         //
         [<Property>]
@@ -236,7 +240,7 @@ module Vector3 =
 
             Assert.ApproximatelyEqual(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Subtraction =
         //
         [<Property>]
@@ -263,7 +267,7 @@ module Vector3 =
 
             Assert.ApproximatelyEqual(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Multiplication =
         //
         [<Property>]
@@ -344,7 +348,7 @@ module Vector3 =
 
             Assert.ApproximatelyEqual(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Division =
         //
         [<Property>]
@@ -358,37 +362,37 @@ module Vector3 =
 
         [<Property>]
         let ``Static Vector3-Vector3 division method is the same as component division`` (a : Vector3, b : Vector3) =
+            if not (anyZero3 a || anyZero3 b) then
+                let v1 = Vector3(a.X / b.X, a.Y / b.Y, a.Z / b.Z)
+                let sum = Vector3.Divide(a, b)
 
-            let v1 = Vector3(a.X / b.X, a.Y / b.Y, a.Z / b.Z)
-            let sum = Vector3.Divide(a, b)
-
-            Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEqual(v1, sum)
 
         [<Property>]
         let ``Static Vector3-Vector3 divison method by reference is the same as component division`` (a : Vector3, b : Vector3) =
+            if not (anyZero3 a || anyZero3 b) then
+                let v1 = Vector3(a.X / b.X, a.Y / b.Y, a.Z / b.Z)
+                let sum = Vector3.Divide(ref a, ref b)
 
-            let v1 = Vector3(a.X / b.X, a.Y / b.Y, a.Z / b.Z)
-            let sum = Vector3.Divide(ref a, ref b)
-
-            Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEqual(v1, sum)
 
         [<Property>]
         let ``Static Vector3-scalar division method is the same as component division`` (a : Vector3, b : float32) =
+            if not (approxEq b 0.0f) then // we don't support diving by zero.
+                let v1 = Vector3(a.X / b, a.Y / b, a.Z / b)
+                let sum = Vector3.Divide(a, b)
 
-            let v1 = Vector3(a.X / b, a.Y / b, a.Z / b)
-            let sum = Vector3.Divide(a, b)
-
-            Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEqual(v1, sum)
 
         [<Property>]
         let ``Static Vector3-scalar divison method by reference is the same as component division`` (a : Vector3, b : float32) =
+            if not (approxEq b 0.0f) then // we don't support diving by zero.
+                let v1 = Vector3(a.X / b, a.Y / b, a.Z / b)
+                let sum = Vector3.Divide(ref a, b)
 
-            let v1 = Vector3(a.X / b, a.Y / b, a.Z / b)
-            let sum = Vector3.Divide(ref a, b)
+                Assert.ApproximatelyEqual(v1, sum)
 
-            Assert.ApproximatelyEqual(v1, sum)
-
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Negation =
         //
         [<Property>]
@@ -399,7 +403,7 @@ module Vector3 =
             Assert.Equal(-y, vNeg.Y)
             Assert.Equal(-z, vNeg.Z)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Equality =
         //
         [<Property>]
@@ -430,7 +434,7 @@ module Vector3 =
             Assert.True(equality)
             Assert.False(inequalityByOtherType)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Swizzling =
         //
         [<Property>]
@@ -475,7 +479,7 @@ module Vector3 =
             Assert.Equal(zx, v.Zx);
             Assert.Equal(zy, v.Zy);
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Interpolation =
         //
         [<Property>]
@@ -503,7 +507,7 @@ module Vector3 =
             let vRes = Vector3.BaryCentric(ref a, ref b, ref c, u, v)
             Assert.Equal(r, vRes)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Vector products`` =
         //
         [<Property>]
@@ -527,66 +531,74 @@ module Vector3 =
             let vRes = Vector3.Cross(ref a, ref b)
             Assert.Equal(cross, vRes)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Magnitude min and max`` =
         //
         [<Property>]
         let ``MagnitudeMin selects the vector with equal or lesser magnitude given two vectors`` (v1 : Vector3, v2: Vector3) =
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
+            // Results do not matter for equal vectors
+            if not (v1 = v2) then
+                let l1 = v1.LengthSquared
+                let l2 = v2.LengthSquared
 
-            let vMin = Vector3.MagnitudeMin(v1, v2)
+                let vMin = Vector3.MagnitudeMin(v1, v2)
 
-            if vMin = v1 then
-                let v1ShorterThanv2 = l1 < l2
-                Assert.True(v1ShorterThanv2)
-            else
-                let v2ShorterThanOrEqualTov1 = l2 <= l1
-                Assert.True(v2ShorterThanOrEqualTov1)
+                if vMin = v1 then
+                    let v1ShorterThanv2 = l1 < l2
+                    Assert.True(v1ShorterThanv2)
+                else
+                    let v2ShorterThanOrEqualTov1 = l2 <= l1
+                    Assert.True(v2ShorterThanOrEqualTov1)
 
         [<Property>]
         let ``MagnitudeMax selects the vector with equal or greater magnitude given two vectors`` (v1 : Vector3, v2: Vector3) =
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
+            // Results do not matter for equal vectors
+            if not (v1 = v2) then
+                let l1 = v1.LengthSquared
+                let l2 = v2.LengthSquared
 
-            let vMin = Vector3.MagnitudeMax(v1, v2)
+                let vMin = Vector3.MagnitudeMax(v1, v2)
 
-            if vMin = v1 then
-                let v1LongerThanOrEqualTov2 = l1 >= l2
-                Assert.True(v1LongerThanOrEqualTov2)
-            else
-                let v2LongerThanv1 = l2 > l1
-                Assert.True(v2LongerThanv1)
+                if vMin = v1 then
+                    let v1LongerThanOrEqualTov2 = l1 >= l2
+                    Assert.True(v1LongerThanOrEqualTov2)
+                else
+                    let v2LongerThanv1 = l2 > l1
+                    Assert.True(v2LongerThanv1)
 
         [<Property>]
         let ``MagnitudeMin by reference selects the vector with equal or lesser magnitude given two vectors`` (v1 : Vector3, v2: Vector3) =
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
+            // Results do not matter for equal vectors
+            if not (v1 = v2) then
+                let l1 = v1.LengthSquared
+                let l2 = v2.LengthSquared
 
-            let vMin = Vector3.MagnitudeMin(ref v1, ref v2)
+                let vMin = Vector3.MagnitudeMin(ref v1, ref v2)
 
-            if vMin = v1 then
-                let v1ShorterThanv2 = l1 < l2
-                Assert.True(v1ShorterThanv2)
-            else
-                let v2ShorterThanOrEqualTov1 = l2 <= l1
-                Assert.True(v2ShorterThanOrEqualTov1)
+                if vMin = v1 then
+                    let v1ShorterThanv2 = l1 < l2
+                    Assert.True(v1ShorterThanv2)
+                else
+                    let v2ShorterThanOrEqualTov1 = l2 <= l1
+                    Assert.True(v2ShorterThanOrEqualTov1)
 
         [<Property>]
         let ``MagnitudeMax by reference selects the vector with equal or greater magnitude given two vectors`` (v1 : Vector3, v2: Vector3) =
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
+            // Results do not matter for equal vectors
+            if not (v1 = v2) then
+                let l1 = v1.LengthSquared
+                let l2 = v2.LengthSquared
 
-            let vMin = Vector3.MagnitudeMax(ref v1, ref v2)
+                let vMin = Vector3.MagnitudeMax(ref v1, ref v2)
 
-            if vMin = v1 then
-                let v1LongerThanOrEqualTov2 = l1 >= l2
-                Assert.True(v1LongerThanOrEqualTov2)
-            else
-                let v2LongerThanv1 = l2 > l1
-                Assert.True(v2LongerThanv1)
+                if vMin = v1 then
+                    let v1LongerThanOrEqualTov2 = l1 >= l2
+                    Assert.True(v1LongerThanOrEqualTov2)
+                else
+                    let v2LongerThanv1 = l2 > l1
+                    Assert.True(v2LongerThanv1)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Component min and max`` =
         //
         [<Property>]
@@ -625,7 +637,7 @@ module Vector3 =
             Assert.True(isComponentLargest vMax.Y v1.Y v2.Y)
             Assert.True(isComponentLargest vMax.Z v1.Z v2.Z)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Clamping =
         //
         [<Property>]
@@ -652,7 +664,7 @@ module Vector3 =
             Assert.Equal(expY, res.Y)
             Assert.Equal(expZ, res.Z)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Unit vectors``=
         //
         [<Property>]
@@ -685,7 +697,7 @@ module Vector3 =
 
             Assert.Equal(Vector3.One, unitOne)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Serialization =
         //
         [<Property>]
@@ -695,7 +707,7 @@ module Vector3 =
             Assert.Equal(expectedSize, Vector3.SizeInBytes)
             Assert.Equal(expectedSize, Marshal.SizeOf(Vector3()))
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Transformation =
         //
         [<Property>]

--- a/tests/OpenTK.Tests/Vector4Tests.fs
+++ b/tests/OpenTK.Tests/Vector4Tests.fs
@@ -8,7 +8,7 @@ open System.Runtime.InteropServices
 open OpenTK
 
 module Vector4 =
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Constructors =
         //
         [<Property>]
@@ -85,7 +85,7 @@ module Vector4 =
             Assert.Equal(z, v2.Z)
             Assert.Equal(w, v2.W)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Indexing =
         //
         [<Property>]
@@ -121,7 +121,7 @@ module Vector4 =
 
             (fun() -> v.[4] |> ignore) |> Assert.ThrowsIndexExn
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Length =
         //
         [<Property>]
@@ -145,7 +145,7 @@ module Vector4 =
 
             Assert.Equal(lsq, v.LengthSquared)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Normalization =
         //
         [<Property>]
@@ -157,10 +157,10 @@ module Vector4 =
             if not (approxEq l 0.0f) then
                 let norm = v.Normalized()
 
-                Assert.ApproximatelyEqual(v.X / l, norm.X)
-                Assert.ApproximatelyEqual(v.Y / l, norm.Y)
-                Assert.ApproximatelyEqual(v.Z / l, norm.Z)
-                Assert.ApproximatelyEqual(v.W / l, norm.W)
+                Assert.ApproximatelyEquivalent(v.X / l, norm.X)
+                Assert.ApproximatelyEquivalent(v.Y / l, norm.Y)
+                Assert.ApproximatelyEquivalent(v.Z / l, norm.Z)
+                Assert.ApproximatelyEquivalent(v.W / l, norm.W)
 
         [<Property>]
         let ``Normalization of instance transforms the instance into a unit length vector with the correct components`` (x, y, z, w) =
@@ -172,10 +172,10 @@ module Vector4 =
                 let norm = Vector4(x, y, z, w)
                 norm.Normalize()
 
-                Assert.ApproximatelyEqual(v.X / l, norm.X)
-                Assert.ApproximatelyEqual(v.Y / l, norm.Y)
-                Assert.ApproximatelyEqual(v.Z / l, norm.Z)
-                Assert.ApproximatelyEqual(v.W / l, norm.W)
+                Assert.ApproximatelyEquivalent(v.X / l, norm.X)
+                Assert.ApproximatelyEquivalent(v.Y / l, norm.Y)
+                Assert.ApproximatelyEquivalent(v.Z / l, norm.Z)
+                Assert.ApproximatelyEquivalent(v.W / l, norm.W)
 
         [<Property>]
         let ``Fast approximate normalization of instance transforms the instance into a unit length vector with the correct components`` (x, y, z, w) =
@@ -185,10 +185,10 @@ module Vector4 =
 
             let scale = MathHelper.InverseSqrtFast(x * x + y * y + z * z + w * w)
 
-            Assert.ApproximatelyEqual(v.X * scale, norm.X)
-            Assert.ApproximatelyEqual(v.Y * scale, norm.Y)
-            Assert.ApproximatelyEqual(v.Z * scale, norm.Z)
-            Assert.ApproximatelyEqual(v.W * scale, norm.W)
+            Assert.ApproximatelyEquivalent(v.X * scale, norm.X)
+            Assert.ApproximatelyEquivalent(v.Y * scale, norm.Y)
+            Assert.ApproximatelyEquivalent(v.Z * scale, norm.Z)
+            Assert.ApproximatelyEquivalent(v.W * scale, norm.W)
 
         [<Property>]
         let ``Normalization by reference is the same as division by magnitude`` (a : Vector4) =
@@ -197,7 +197,7 @@ module Vector4 =
                 let norm = a / a.Length
                 let vRes = Vector4.Normalize(ref a)
 
-                Assert.ApproximatelyEqual(norm, vRes)
+                Assert.ApproximatelyEquivalent(norm, vRes)
 
         [<Property>]
         let ``Normalization is the same as division by magnitude`` (a : Vector4) =
@@ -205,7 +205,7 @@ module Vector4 =
             if not (approxEq a.Length 0.0f) then
                 let norm = a / a.Length
 
-                Assert.ApproximatelyEqual(norm, Vector4.Normalize(a));
+                Assert.ApproximatelyEquivalent(norm, Vector4.Normalize(a));
 
         [<Property>]
         let ``Fast approximate normalization by reference is the same as multiplication by the fast inverse square`` (a : Vector4) =
@@ -214,40 +214,40 @@ module Vector4 =
             let norm = a * scale
             let vRes = Vector4.NormalizeFast(ref a)
 
-            Assert.ApproximatelyEqual(norm, vRes)
+            Assert.ApproximatelyEquivalent(norm, vRes)
 
         [<Property>]
         let ``Fast approximate normalization is the same as multiplication by the fast inverse square`` (a : Vector4) =
             let scale = MathHelper.InverseSqrtFast(a.X * a.X + a.Y * a.Y + a.Z * a.Z + a.W * a.W)
             let norm = a * scale
 
-            Assert.ApproximatelyEqual(norm, Vector4.NormalizeFast(a));
+            Assert.ApproximatelyEquivalent(norm, Vector4.NormalizeFast(a));
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Addition =
         //
         [<Property>]
         let ``Vector4 addition is the same as component addition`` (a : Vector4, b : Vector4) =
             let c = a + b
 
-            Assert.ApproximatelyEqual(a.X + b.X,c.X)
-            Assert.ApproximatelyEqual(a.Y + b.Y,c.Y)
-            Assert.ApproximatelyEqual(a.Z + b.Z,c.Z)
-            Assert.ApproximatelyEqual(a.W + b.W,c.W)
+            Assert.ApproximatelyEquivalent(a.X + b.X,c.X)
+            Assert.ApproximatelyEquivalent(a.Y + b.Y,c.Y)
+            Assert.ApproximatelyEquivalent(a.Z + b.Z,c.Z)
+            Assert.ApproximatelyEquivalent(a.W + b.W,c.W)
 
         [<Property>]
         let ``Vector4 addition is commutative`` (a : Vector4, b : Vector4) =
             let c = a + b
             let c2 = b + a
 
-            Assert.ApproximatelyEqual(c, c2)
+            Assert.ApproximatelyEquivalent(c, c2)
 
         [<Property>]
         let ``Vector4 addition is associative`` (a : Vector4, b : Vector4, c : Vector4) =
             let r1 = (a + b) + c
             let r2 = a + (b + c)
 
-            Assert.ApproximatelyEqual(r1, r2)
+            Assert.ApproximatelyEquivalent(r1, r2)
 
         [<Property>]
         let ``Static Vector4 addition method is the same as component addition`` (a : Vector4, b : Vector4) =
@@ -255,7 +255,7 @@ module Vector4 =
             let v1 = Vector4(a.X + b.X, a.Y + b.Y, a.Z + b.Z, a.W + b.W)
             let sum = Vector4.Add(a, b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector4 addition method by reference is the same as component addition`` (a : Vector4, b : Vector4) =
@@ -263,9 +263,9 @@ module Vector4 =
             let v1 = Vector4(a.X + b.X, a.Y + b.Y, a.Z + b.Z, a.W + b.W)
             let sum = Vector4.Add(ref a, ref b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Subtraction =
         //
         [<Property>]
@@ -283,7 +283,7 @@ module Vector4 =
             let v1 = Vector4(a.X - b.X, a.Y - b.Y, a.Z - b.Z, a.W - b.W)
             let sum = Vector4.Subtract(a, b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector4 subtraction method by reference is the same as component addition`` (a : Vector4, b : Vector4) =
@@ -291,9 +291,9 @@ module Vector4 =
             let v1 = Vector4(a.X - b.X, a.Y - b.Y, a.Z - b.Z, a.W - b.W)
             let sum = Vector4.Subtract(ref a, ref b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Multiplication =
         //
         [<Property>]
@@ -371,7 +371,7 @@ module Vector4 =
             let v1 = Vector4(a.X * b.X, a.Y * b.Y, a.Z * b.Z, a.W * b.W)
             let sum = Vector4.Multiply(a, b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector4 multiplication method by reference is the same as component multiplication`` (a : Vector4, b : Vector4) =
@@ -379,9 +379,9 @@ module Vector4 =
             let v1 = Vector4(a.X * b.X, a.Y * b.Y, a.Z * b.Z, a.W * b.W)
             let sum = Vector4.Multiply(ref a, ref b)
 
-            Assert.ApproximatelyEqual(v1, sum)
+            Assert.ApproximatelyEquivalent(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Division =
         //
         [<Property>]
@@ -389,10 +389,10 @@ module Vector4 =
             if not (approxEq f 0.0f) then // we don't support diving by zero.
                 let r = a / f
 
-                Assert.ApproximatelyEqual(a.X / f, r.X)
-                Assert.ApproximatelyEqual(a.Y / f, r.Y)
-                Assert.ApproximatelyEqual(a.Z / f, r.Z)
-                Assert.ApproximatelyEqual(a.W / f, r.W)
+                Assert.ApproximatelyEquivalent(a.X / f, r.X)
+                Assert.ApproximatelyEquivalent(a.Y / f, r.Y)
+                Assert.ApproximatelyEquivalent(a.Z / f, r.Z)
+                Assert.ApproximatelyEquivalent(a.W / f, r.W)
 
         [<Property>]
         let ``Static Vector4-Vector4 division method is the same as component division`` (a : Vector4, b : Vector4) =
@@ -400,7 +400,7 @@ module Vector4 =
                 let v1 = Vector4(a.X / b.X, a.Y / b.Y, a.Z / b.Z, a.W / b.W)
                 let sum = Vector4.Divide(a, b)
 
-                Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector4-Vector4 divison method by reference is the same as component division`` (a : Vector4, b : Vector4) =
@@ -408,7 +408,7 @@ module Vector4 =
                 let v1 = Vector4(a.X / b.X, a.Y / b.Y, a.Z / b.Z, a.W / b.W)
                 let sum = Vector4.Divide(ref a, ref b)
 
-                Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector4-scalar division method is the same as component division`` (a : Vector4, b : float32) =
@@ -416,7 +416,7 @@ module Vector4 =
                 let v1 = Vector4(a.X / b, a.Y / b, a.Z / b, a.W / b)
                 let sum = Vector4.Divide(a, b)
 
-                Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEquivalent(v1, sum)
 
         [<Property>]
         let ``Static Vector4-scalar divison method by reference is the same as component division`` (a : Vector4, b : float32) =
@@ -424,9 +424,9 @@ module Vector4 =
                 let v1 = Vector4(a.X / b, a.Y / b, a.Z / b, a.W / b)
                 let sum = Vector4.Divide(ref a, b)
 
-                Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEquivalent(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Negation =
         //
         [<Property>]
@@ -438,7 +438,7 @@ module Vector4 =
             Assert.Equal(-z, vNeg.Z)
             Assert.Equal(-w, vNeg.W)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Equality =
         //
         [<Property>]
@@ -478,7 +478,7 @@ module Vector4 =
 
             Assert.False(inequalityByOtherType)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Swizzling =
         //
         [<Property>]
@@ -657,7 +657,7 @@ module Vector4 =
             Assert.Equal(wy, v.Wy)
             Assert.Equal(wz, v.Wz)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Interpolation =
         //
         [<Property>]
@@ -686,7 +686,7 @@ module Vector4 =
             let vRes = Vector4.BaryCentric(ref a, ref b, ref c, u, v)
             Assert.Equal(r, vRes)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Vector products`` =
         //
         [<Property>]
@@ -698,7 +698,7 @@ module Vector4 =
             let vRes = Vector4.Dot(ref a, ref b)
             Assert.Equal(dot, vRes)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Magnitude min and max`` =
         //
         [<Property>]
@@ -765,7 +765,7 @@ module Vector4 =
                     let v2LongerThanv1 = l2 > l1
                     Assert.True(v2LongerThanv1)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Component min and max`` =
         //
         [<Property>]
@@ -809,7 +809,7 @@ module Vector4 =
             Assert.True(isComponentLargest vMax.W v1.W v2.W)
 
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Clamping =
         //
         [<Property>]
@@ -840,7 +840,7 @@ module Vector4 =
             Assert.Equal(expZ, res.Z)
             Assert.Equal(expW, res.W)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module ``Unit vectors``=
         //
         [<Property>]
@@ -879,7 +879,7 @@ module Vector4 =
 
             Assert.Equal(Vector4.One, unitOne)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Serialization =
         //
         [<Property>]
@@ -889,7 +889,7 @@ module Vector4 =
             Assert.Equal(expectedSize, Vector4.SizeInBytes)
             Assert.Equal(expectedSize, Marshal.SizeOf(Vector4()))
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Transformation =
         //
         [<Property>]
@@ -900,7 +900,7 @@ module Vector4 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = Vector4(transformedQuat.X, transformedQuat.Y, transformedQuat.Z, transformedQuat.W)
 
-            Assert.ApproximatelyEqual(transformedVector, Vector4.Transform(v, q))
+            Assert.ApproximatelyEquivalent(transformedVector, Vector4.Transform(v, q))
 
         [<Property>]
         let ``Transformation by quaternion with static method by reference is the same as multiplication by quaternion and its conjugate`` (v : Vector4, q : Quaternion) =
@@ -910,7 +910,7 @@ module Vector4 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = Vector4(transformedQuat.X, transformedQuat.Y,transformedQuat.Z, transformedQuat.W)
 
-            Assert.ApproximatelyEqual(transformedVector, Vector4.Transform(ref v, ref q))
+            Assert.ApproximatelyEquivalent(transformedVector, Vector4.Transform(ref v, ref q))
 
         [<Property>]
         let ``Transformation by quaternion by multiplication using right-handed notation is the same as multiplication by quaternion and its conjugate`` (v : Vector4, q : Quaternion) =
@@ -920,4 +920,4 @@ module Vector4 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = Vector4(transformedQuat.X, transformedQuat.Y, transformedQuat.Z, transformedQuat.W)
 
-            Assert.ApproximatelyEqual(transformedVector, q * v)
+            Assert.ApproximatelyEquivalent(transformedVector, q * v)

--- a/tests/OpenTK.Tests/Vector4Tests.fs
+++ b/tests/OpenTK.Tests/Vector4Tests.fs
@@ -885,7 +885,7 @@ module Vector4 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = Vector4(transformedQuat.X, transformedQuat.Y, transformedQuat.Z, transformedQuat.W)
 
-            Assert.Equal(transformedVector, Vector4.Transform(v, q))
+            Assert.ApproximatelyEqual(transformedVector, Vector4.Transform(v, q))
 
         [<Property>]
         let ``Transformation by quaternion with static method by reference is the same as multiplication by quaternion and its conjugate`` (v : Vector4, q : Quaternion) =
@@ -895,7 +895,7 @@ module Vector4 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = Vector4(transformedQuat.X, transformedQuat.Y,transformedQuat.Z, transformedQuat.W)
 
-            Assert.Equal(transformedVector, Vector4.Transform(ref v, ref q))
+            Assert.ApproximatelyEqual(transformedVector, Vector4.Transform(ref v, ref q))
 
         [<Property>]
         let ``Transformation by quaternion by multiplication using right-handed notation is the same as multiplication by quaternion and its conjugate`` (v : Vector4, q : Quaternion) =
@@ -905,4 +905,4 @@ module Vector4 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = Vector4(transformedQuat.X, transformedQuat.Y, transformedQuat.Z, transformedQuat.W)
 
-            Assert.Equal(transformedVector, q * v)
+            Assert.ApproximatelyEqual(transformedVector, q * v)

--- a/tests/OpenTK.Tests/Vector4Tests.fs
+++ b/tests/OpenTK.Tests/Vector4Tests.fs
@@ -8,7 +8,7 @@ open System.Runtime.InteropServices
 open OpenTK
 
 module Vector4 =
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Constructors =
         //
         [<Property>]
@@ -85,7 +85,7 @@ module Vector4 =
             Assert.Equal(z, v2.Z)
             Assert.Equal(w, v2.W)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Indexing =
         //
         [<Property>]
@@ -121,7 +121,7 @@ module Vector4 =
 
             (fun() -> v.[4] |> ignore) |> Assert.ThrowsIndexExn
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Length =
         //
         [<Property>]
@@ -145,7 +145,7 @@ module Vector4 =
 
             Assert.Equal(lsq, v.LengthSquared)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Normalization =
         //
         [<Property>]
@@ -153,25 +153,29 @@ module Vector4 =
             let v = Vector4(x, y, z, w)
             let l = v.Length
 
-            let norm = v.Normalized()
+            // Zero-length vectors can't be normalized
+            if not (approxEq l 0.0f) then
+                let norm = v.Normalized()
 
-            Assert.ApproximatelyEqual(v.X / l, norm.X)
-            Assert.ApproximatelyEqual(v.Y / l, norm.Y)
-            Assert.ApproximatelyEqual(v.Z / l, norm.Z)
-            Assert.ApproximatelyEqual(v.W / l, norm.W)
+                Assert.ApproximatelyEqual(v.X / l, norm.X)
+                Assert.ApproximatelyEqual(v.Y / l, norm.Y)
+                Assert.ApproximatelyEqual(v.Z / l, norm.Z)
+                Assert.ApproximatelyEqual(v.W / l, norm.W)
 
         [<Property>]
         let ``Normalization of instance transforms the instance into a unit length vector with the correct components`` (x, y, z, w) =
             let v = Vector4(x, y, z, w)
             let l = v.Length
 
-            let norm = Vector4(x, y, z, w)
-            norm.Normalize()
+            // Zero-length vectors can't be normalized
+            if not (approxEq l 0.0f) then
+                let norm = Vector4(x, y, z, w)
+                norm.Normalize()
 
-            Assert.ApproximatelyEqual(v.X / l, norm.X)
-            Assert.ApproximatelyEqual(v.Y / l, norm.Y)
-            Assert.ApproximatelyEqual(v.Z / l, norm.Z)
-            Assert.ApproximatelyEqual(v.W / l, norm.W)
+                Assert.ApproximatelyEqual(v.X / l, norm.X)
+                Assert.ApproximatelyEqual(v.Y / l, norm.Y)
+                Assert.ApproximatelyEqual(v.Z / l, norm.Z)
+                Assert.ApproximatelyEqual(v.W / l, norm.W)
 
         [<Property>]
         let ``Fast approximate normalization of instance transforms the instance into a unit length vector with the correct components`` (x, y, z, w) =
@@ -188,16 +192,20 @@ module Vector4 =
 
         [<Property>]
         let ``Normalization by reference is the same as division by magnitude`` (a : Vector4) =
-            let norm = a / a.Length
-            let vRes = Vector4.Normalize(ref a)
+            // Zero-length vectors can't be normalized
+            if not (approxEq a.Length 0.0f) then
+                let norm = a / a.Length
+                let vRes = Vector4.Normalize(ref a)
 
-            Assert.ApproximatelyEqual(norm, vRes)
+                Assert.ApproximatelyEqual(norm, vRes)
 
         [<Property>]
         let ``Normalization is the same as division by magnitude`` (a : Vector4) =
-            let norm = a / a.Length
+            // Zero-length vectors can't be normalized
+            if not (approxEq a.Length 0.0f) then
+                let norm = a / a.Length
 
-            Assert.ApproximatelyEqual(norm, Vector4.Normalize(a));
+                Assert.ApproximatelyEqual(norm, Vector4.Normalize(a));
 
         [<Property>]
         let ``Fast approximate normalization by reference is the same as multiplication by the fast inverse square`` (a : Vector4) =
@@ -211,12 +219,11 @@ module Vector4 =
         [<Property>]
         let ``Fast approximate normalization is the same as multiplication by the fast inverse square`` (a : Vector4) =
             let scale = MathHelper.InverseSqrtFast(a.X * a.X + a.Y * a.Y + a.Z * a.Z + a.W * a.W)
-
             let norm = a * scale
 
             Assert.ApproximatelyEqual(norm, Vector4.NormalizeFast(a));
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Addition =
         //
         [<Property>]
@@ -258,7 +265,7 @@ module Vector4 =
 
             Assert.ApproximatelyEqual(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Subtraction =
         //
         [<Property>]
@@ -286,7 +293,7 @@ module Vector4 =
 
             Assert.ApproximatelyEqual(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Multiplication =
         //
         [<Property>]
@@ -374,7 +381,7 @@ module Vector4 =
 
             Assert.ApproximatelyEqual(v1, sum)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Division =
         //
         [<Property>]
@@ -389,37 +396,37 @@ module Vector4 =
 
         [<Property>]
         let ``Static Vector4-Vector4 division method is the same as component division`` (a : Vector4, b : Vector4) =
+            if not (anyZero4 a || anyZero4 b) then
+                let v1 = Vector4(a.X / b.X, a.Y / b.Y, a.Z / b.Z, a.W / b.W)
+                let sum = Vector4.Divide(a, b)
 
-            let v1 = Vector4(a.X / b.X, a.Y / b.Y, a.Z / b.Z, a.W / b.W)
-            let sum = Vector4.Divide(a, b)
-
-            Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEqual(v1, sum)
 
         [<Property>]
         let ``Static Vector4-Vector4 divison method by reference is the same as component division`` (a : Vector4, b : Vector4) =
+            if not (anyZero4 a || anyZero4 b) then
+                let v1 = Vector4(a.X / b.X, a.Y / b.Y, a.Z / b.Z, a.W / b.W)
+                let sum = Vector4.Divide(ref a, ref b)
 
-            let v1 = Vector4(a.X / b.X, a.Y / b.Y, a.Z / b.Z, a.W / b.W)
-            let sum = Vector4.Divide(ref a, ref b)
-
-            Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEqual(v1, sum)
 
         [<Property>]
         let ``Static Vector4-scalar division method is the same as component division`` (a : Vector4, b : float32) =
+            if not (approxEq b 0.0f) then // we don't support diving by zero.
+                let v1 = Vector4(a.X / b, a.Y / b, a.Z / b, a.W / b)
+                let sum = Vector4.Divide(a, b)
 
-            let v1 = Vector4(a.X / b, a.Y / b, a.Z / b, a.W / b)
-            let sum = Vector4.Divide(a, b)
-
-            Assert.ApproximatelyEqual(v1, sum)
+                Assert.ApproximatelyEqual(v1, sum)
 
         [<Property>]
         let ``Static Vector4-scalar divison method by reference is the same as component division`` (a : Vector4, b : float32) =
+            if not (approxEq b 0.0f) then // we don't support diving by zero.
+                let v1 = Vector4(a.X / b, a.Y / b, a.Z / b, a.W / b)
+                let sum = Vector4.Divide(ref a, b)
 
-            let v1 = Vector4(a.X / b, a.Y / b, a.Z / b, a.W / b)
-            let sum = Vector4.Divide(ref a, b)
+                Assert.ApproximatelyEqual(v1, sum)
 
-            Assert.ApproximatelyEqual(v1, sum)
-
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Negation =
         //
         [<Property>]
@@ -431,7 +438,7 @@ module Vector4 =
             Assert.Equal(-z, vNeg.Z)
             Assert.Equal(-w, vNeg.W)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Equality =
         //
         [<Property>]
@@ -471,7 +478,7 @@ module Vector4 =
 
             Assert.False(inequalityByOtherType)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Swizzling =
         //
         [<Property>]
@@ -650,7 +657,7 @@ module Vector4 =
             Assert.Equal(wy, v.Wy)
             Assert.Equal(wz, v.Wz)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Interpolation =
         //
         [<Property>]
@@ -679,7 +686,7 @@ module Vector4 =
             let vRes = Vector4.BaryCentric(ref a, ref b, ref c, u, v)
             Assert.Equal(r, vRes)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Vector products`` =
         //
         [<Property>]
@@ -691,66 +698,74 @@ module Vector4 =
             let vRes = Vector4.Dot(ref a, ref b)
             Assert.Equal(dot, vRes)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Magnitude min and max`` =
         //
         [<Property>]
         let ``MagnitudeMin selects the vector with equal or lesser magnitude given two vectors`` (v1 : Vector4, v2: Vector4) =
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
+            // Results do not matter for equal vectors
+            if not (v1 = v2) then
+                let l1 = v1.LengthSquared
+                let l2 = v2.LengthSquared
 
-            let vMin = Vector4.MagnitudeMin(v1, v2)
+                let vMin = Vector4.MagnitudeMin(v1, v2)
 
-            if vMin = v1 then
-                let v1ShorterThanv2 = l1 < l2
-                Assert.True(v1ShorterThanv2)
-            else
-                let v2ShorterThanOrEqualTov1 = l2 <= l1
-                Assert.True(v2ShorterThanOrEqualTov1)
+                if vMin = v1 then
+                    let v1ShorterThanv2 = l1 < l2
+                    Assert.True(v1ShorterThanv2)
+                else
+                    let v2ShorterThanOrEqualTov1 = l2 <= l1
+                    Assert.True(v2ShorterThanOrEqualTov1)
 
         [<Property>]
         let ``MagnitudeMax selects the vector with equal or greater magnitude given two vectors`` (v1 : Vector4, v2: Vector4) =
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
+            // Results do not matter for equal vectors
+            if not (v1 = v2) then
+                let l1 = v1.LengthSquared
+                let l2 = v2.LengthSquared
 
-            let vMin = Vector4.MagnitudeMax(v1, v2)
+                let vMin = Vector4.MagnitudeMax(v1, v2)
 
-            if vMin = v1 then
-                let v1LongerThanOrEqualTov2 = l1 >= l2
-                Assert.True(v1LongerThanOrEqualTov2)
-            else
-                let v2LongerThanv1 = l2 > l1
-                Assert.True(v2LongerThanv1)
+                if vMin = v1 then
+                    let v1LongerThanOrEqualTov2 = l1 >= l2
+                    Assert.True(v1LongerThanOrEqualTov2)
+                else
+                    let v2LongerThanv1 = l2 > l1
+                    Assert.True(v2LongerThanv1)
 
         [<Property>]
         let ``MagnitudeMin by reference selects the vector with equal or lesser magnitude given two vectors`` (v1 : Vector4, v2: Vector4) =
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
+            // Results do not matter for equal vectors
+            if not (v1 = v2) then
+                let l1 = v1.LengthSquared
+                let l2 = v2.LengthSquared
 
-            let vMin = Vector4.MagnitudeMin(ref v1, ref v2)
+                let vMin = Vector4.MagnitudeMin(ref v1, ref v2)
 
-            if vMin = v1 then
-                let v1ShorterThanv2 = l1 < l2
-                Assert.True(v1ShorterThanv2)
-            else
-                let v2ShorterThanOrEqualTov1 = l2 <= l1
-                Assert.True(v2ShorterThanOrEqualTov1)
+                if vMin = v1 then
+                    let v1ShorterThanv2 = l1 < l2
+                    Assert.True(v1ShorterThanv2)
+                else
+                    let v2ShorterThanOrEqualTov1 = l2 <= l1
+                    Assert.True(v2ShorterThanOrEqualTov1)
 
         [<Property>]
         let ``MagnitudeMax by reference selects the vector with equal or greater magnitude given two vectors`` (v1 : Vector4, v2: Vector4) =
-            let l1 = v1.LengthSquared
-            let l2 = v2.LengthSquared
+            // Results do not matter for equal vectors
+            if not (v1 = v2) then
+                let l1 = v1.LengthSquared
+                let l2 = v2.LengthSquared
 
-            let vMin = Vector4.MagnitudeMax(ref v1, ref v2)
+                let vMin = Vector4.MagnitudeMax(ref v1, ref v2)
 
-            if vMin = v1 then
-                let v1LongerThanOrEqualTov2 = l1 >= l2
-                Assert.True(v1LongerThanOrEqualTov2)
-            else
-                let v2LongerThanv1 = l2 > l1
-                Assert.True(v2LongerThanv1)
+                if vMin = v1 then
+                    let v1LongerThanOrEqualTov2 = l1 >= l2
+                    Assert.True(v1LongerThanOrEqualTov2)
+                else
+                    let v2LongerThanv1 = l2 > l1
+                    Assert.True(v2LongerThanv1)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Component min and max`` =
         //
         [<Property>]
@@ -794,7 +809,7 @@ module Vector4 =
             Assert.True(isComponentLargest vMax.W v1.W v2.W)
 
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Clamping =
         //
         [<Property>]
@@ -825,7 +840,7 @@ module Vector4 =
             Assert.Equal(expZ, res.Z)
             Assert.Equal(expW, res.W)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module ``Unit vectors``=
         //
         [<Property>]
@@ -864,7 +879,7 @@ module Vector4 =
 
             Assert.Equal(Vector4.One, unitOne)
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Serialization =
         //
         [<Property>]
@@ -874,7 +889,7 @@ module Vector4 =
             Assert.Equal(expectedSize, Vector4.SizeInBytes)
             Assert.Equal(expectedSize, Marshal.SizeOf(Vector4()))
 
-    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |], MaxTest = 10000)>]
     module Transformation =
         //
         [<Property>]


### PR DESCRIPTION
This PR adds two new approximation algorithms for single- and double-precision floating-point numbers. ApproximatelyEqualEpsilon is an equality approximation function which is designed to determine equality of two given numbers on any inferred scale or order of magnitude. ApproximatelyEquivalent is an equivalence approximation, designed to only consider equivalence on a human scale, and not direct equality.

The latter algorithm has been made the default method in all unit tests, and tests inputs to a tolerance of 0.00005f. Using this algorithm, all tests hold over three runs of 10k iterations.

Furthermore, a few more assertion helpers have been added, and code comments for these new algorithms have been expanded. Finally, all affected areas of the code have been given new or updated unit tests.